### PR TITLE
Completed TODO: rename to "Axis"

### DIFF
--- a/LayoutKit.xcodeproj/project.pbxproj
+++ b/LayoutKit.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		0B3D5AEF1CFA5BB50090AD80 /* AxisSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3D5AEC1CFA5BB50090AD80 /* AxisSize.swift */; };
 		0B3D5AF01CFA5BB50090AD80 /* AxisFlexibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3D5AED1CFA5BB50090AD80 /* AxisFlexibility.swift */; };
 		0B3D5AF11CFA5BB50090AD80 /* AxisPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3D5AEE1CFA5BB50090AD80 /* AxisPoint.swift */; };
-		0B5ADBC11CF427510056A568 /* LayoutAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5ADBC01CF427510056A568 /* LayoutAxis.swift */; };
+		0B5ADBC11CF427510056A568 /* Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5ADBC01CF427510056A568 /* Axis.swift */; };
 		0B5ADBC41CF500500056A568 /* FeedItemManualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5ADBC31CF500500056A568 /* FeedItemManualView.swift */; };
 		0B5ADBC61CF500730056A568 /* FeedItemLayoutKitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5ADBC51CF500730056A568 /* FeedItemLayoutKitView.swift */; };
 		0B5ADBC81CF504080056A568 /* FeedItemData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5ADBC71CF504080056A568 /* FeedItemData.swift */; };
@@ -144,7 +144,7 @@
 		0B3D5AEC1CFA5BB50090AD80 /* AxisSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AxisSize.swift; sourceTree = "<group>"; };
 		0B3D5AED1CFA5BB50090AD80 /* AxisFlexibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AxisFlexibility.swift; sourceTree = "<group>"; };
 		0B3D5AEE1CFA5BB50090AD80 /* AxisPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AxisPoint.swift; sourceTree = "<group>"; };
-		0B5ADBC01CF427510056A568 /* LayoutAxis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutAxis.swift; sourceTree = "<group>"; };
+		0B5ADBC01CF427510056A568 /* Axis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Axis.swift; sourceTree = "<group>"; };
 		0B5ADBC31CF500500056A568 /* FeedItemManualView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedItemManualView.swift; sourceTree = "<group>"; };
 		0B5ADBC51CF500730056A568 /* FeedItemLayoutKitView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedItemLayoutKitView.swift; sourceTree = "<group>"; };
 		0B5ADBC71CF504080056A568 /* FeedItemData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedItemData.swift; sourceTree = "<group>"; };
@@ -412,7 +412,7 @@
 				0B3B17351CC58B42002127F0 /* Flexibility.swift */,
 				0B3B17361CC58B42002127F0 /* Layout.swift */,
 				0B3B17381CC58B42002127F0 /* LayoutArrangement.swift */,
-				0B5ADBC01CF427510056A568 /* LayoutAxis.swift */,
+				0B5ADBC01CF427510056A568 /* Axis.swift */,
 				0B3B17371CC58B42002127F0 /* LayoutMeasurement.swift */,
 				0BE47EF71CC57348003820E8 /* Info.plist */,
 			);
@@ -666,7 +666,7 @@
 				0B3D5AF11CFA5BB50090AD80 /* AxisPoint.swift in Sources */,
 				0B3B173A1CC58B42002127F0 /* Flexibility.swift in Sources */,
 				0B3B17311CC58B34002127F0 /* PositioningLayout.swift in Sources */,
-				0B5ADBC11CF427510056A568 /* LayoutAxis.swift in Sources */,
+				0B5ADBC11CF427510056A568 /* Axis.swift in Sources */,
 				0BFDC3981CD803720046DCF0 /* StackView.swift in Sources */,
 				0BAAE17A1CCD930B0046DF14 /* ReloadableViewLayoutAdapter.swift in Sources */,
 				0B3B17301CC58B34002127F0 /* LabelLayout.swift in Sources */,

--- a/LayoutKit/Axis.swift
+++ b/LayoutKit/Axis.swift
@@ -6,13 +6,11 @@
 // software distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
+public enum Axis {
 
-/// TODO: rename to "Axis"
-public enum LayoutAxis {
+	/// The y-axis.
+	case vertical
 
-    /// The y-axis.
-    case vertical
-
-    /// The x-axis.
-    case horizontal
+	/// The x-axis.
+	case horizontal
 }

--- a/LayoutKit/Axis.swift
+++ b/LayoutKit/Axis.swift
@@ -8,9 +8,9 @@
 
 public enum Axis {
 
-	/// The y-axis.
-	case vertical
+    /// The y-axis.
+    case vertical
 
-	/// The x-axis.
-	case horizontal
+    /// The x-axis.
+    case horizontal
 }

--- a/LayoutKit/Flexibility.swift
+++ b/LayoutKit/Flexibility.swift
@@ -105,7 +105,7 @@ public struct Flexibility {
     /**
      Returns the flex along an axis.
      */
-    public func flex(axis: LayoutAxis) -> Flex {
+    public func flex(axis: Axis) -> Flex {
         switch axis {
         case .vertical:
             return vertical

--- a/LayoutKit/Layouts/StackLayout.swift
+++ b/LayoutKit/Layouts/StackLayout.swift
@@ -19,7 +19,7 @@ import UIKit
 public class StackLayout: PositioningLayout<UIView> {
 
     /// The axis along which sublayouts are stacked.
-    public let axis: LayoutAxis
+    public let axis: Axis
 
     /**
      The distance in points between adjacent edges of sublayouts along the axis.
@@ -39,7 +39,7 @@ public class StackLayout: PositioningLayout<UIView> {
     /// The stacked layouts.
     public let sublayouts: [Layout]
 
-    public init(axis: LayoutAxis,
+    public init(axis: Axis,
                 spacing: CGFloat = 0,
                 distribution: Distribution = .fillFlexing,
                 alignment: Alignment = .fill,
@@ -282,7 +282,7 @@ extension StackLayout {
     /**
      Inherit the maximum flexibility of sublayouts along the axis and minimum flexibility of sublayouts across the axis.
      */
-    private static func defaultFlexibility(axis axis: LayoutAxis, sublayouts: [Layout]) -> Flexibility {
+    private static func defaultFlexibility(axis axis: Axis, sublayouts: [Layout]) -> Flexibility {
         let initial = AxisFlexibility(axis: axis, axisFlex: nil, crossFlex: .max)
         return sublayouts.reduce(initial) { (flexibility: AxisFlexibility, sublayout: Layout) -> AxisFlexibility in
             let subflex = AxisFlexibility(axis: axis, flexibility: sublayout.flexibility)

--- a/LayoutKit/Math/AxisFlexibility.swift
+++ b/LayoutKit/Math/AxisFlexibility.swift
@@ -9,7 +9,7 @@
 
 /// A wrapper around Flexibility that makes it easy to do math relative to an axis.
 public struct AxisFlexibility {
-    public let axis: LayoutAxis
+    public let axis: Axis
     public let flexibility: Flexibility
 
     public var axisFlex: Flexibility.Flex {
@@ -34,12 +34,12 @@ public struct AxisFlexibility {
         }
     }
 
-    public init(axis: LayoutAxis, flexibility: Flexibility) {
+    public init(axis: Axis, flexibility: Flexibility) {
         self.axis = axis
         self.flexibility = flexibility
     }
 
-    public init(axis: LayoutAxis, axisFlex: Flexibility.Flex, crossFlex: Flexibility.Flex) {
+    public init(axis: Axis, axisFlex: Flexibility.Flex, crossFlex: Flexibility.Flex) {
         self.axis = axis
         switch axis {
         case .horizontal:

--- a/LayoutKit/Math/AxisPoint.swift
+++ b/LayoutKit/Math/AxisPoint.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// A wrapper around CGPoint that makes it easy to do math relative to an axis.
 public struct AxisPoint {
-    public let axis: LayoutAxis
+    public let axis: Axis
     public var point: CGPoint
 
     public var axisOffset: CGFloat {
@@ -51,12 +51,12 @@ public struct AxisPoint {
         }
     }
 
-    public init(axis: LayoutAxis, point: CGPoint) {
+    public init(axis: Axis, point: CGPoint) {
         self.axis = axis
         self.point = point
     }
 
-    public init(axis: LayoutAxis, axisOffset: CGFloat, crossOffset: CGFloat) {
+    public init(axis: Axis, axisOffset: CGFloat, crossOffset: CGFloat) {
         self.axis = axis
         switch axis {
         case .horizontal:

--- a/LayoutKit/Math/AxisSize.swift
+++ b/LayoutKit/Math/AxisSize.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// A wrapper around CGSize that makes it easy to do math relative to an axis.
 public struct AxisSize {
-    public let axis: LayoutAxis
+    public let axis: Axis
     public var size: CGSize
 
     public var axisLength: CGFloat {
@@ -51,12 +51,12 @@ public struct AxisSize {
         }
     }
 
-    public init(axis: LayoutAxis, size: CGSize) {
+    public init(axis: Axis, size: CGSize) {
         self.axis = axis
         self.size = size
     }
 
-    public init(axis: LayoutAxis, axisLength: CGFloat, crossLength: CGFloat) {
+    public init(axis: Axis, axisLength: CGFloat, crossLength: CGFloat) {
         self.axis = axis
         switch axis {
         case .horizontal:

--- a/LayoutKit/Views/ReloadableView.swift
+++ b/LayoutKit/Views/ReloadableView.swift
@@ -29,7 +29,7 @@ public protocol ReloadableView: class {
     /**
      The axis which is scrollable.
      */
-    func scrollAxis() -> LayoutAxis
+    func scrollAxis() -> Axis
 
     /**
      Reloads the data synchronously.
@@ -55,7 +55,7 @@ public protocol ReloadableView: class {
 /// Make UICollectionView conform to ReloadableView protocol.
 extension UICollectionView: ReloadableView {
     
-    public func scrollAxis() -> LayoutAxis {
+    public func scrollAxis() -> Axis {
         if let flowLayout = collectionViewLayout as? UICollectionViewFlowLayout {
             switch flowLayout.scrollDirection {
             case .Vertical:
@@ -94,7 +94,7 @@ extension UICollectionView: ReloadableView {
 /// Make UITableView conform to ReloadableView protocol.
 extension UITableView: ReloadableView {
 
-    public func scrollAxis() -> LayoutAxis {
+    public func scrollAxis() -> Axis {
         return .vertical
     }
 

--- a/LayoutKit/Views/StackView.swift
+++ b/LayoutKit/Views/StackView.swift
@@ -26,7 +26,7 @@ import UIKit
 public class StackView: UIView {
 
     /// The axis along which arranged views are stacked.
-    public let axis: LayoutAxis
+    public let axis: Axis
 
     /**
      The distance in points between adjacent edges of sublayouts along the axis.
@@ -48,7 +48,7 @@ public class StackView: UIView {
 
     private var arrangedSubviews: [UIView] = []
 
-    public init(axis: LayoutAxis,
+    public init(axis: Axis,
                 spacing: CGFloat = 0,
                 distribution: StackLayout.Distribution = .leading,
                 contentInsets: UIEdgeInsets = UIEdgeInsetsZero,

--- a/LayoutKitTests/TestStack.swift
+++ b/LayoutKitTests/TestStack.swift
@@ -19,7 +19,7 @@ class TestStack {
     var twoView: UIView! = nil
     var threeView: UIView! = nil
 
-    init(axis: LayoutAxis, distribution: StackLayout.Distribution, spacing: CGFloat = 0, alignment: Alignment = .fill) {
+    init(axis: Axis, distribution: StackLayout.Distribution, spacing: CGFloat = 0, alignment: Alignment = .fill) {
 
         switch axis {
         case .vertical:


### PR DESCRIPTION
Hello,

Thank you for LayoutKit, I like what I've seen so far.

I've noticed you had a TODO for renaming "LayoutAxis" to "Axis" in your codebase.
I also agree it simplifies what Axis means and understand this is a minor change.

Commit description:
% Renamed LayoutAxis.swift -> Axis.swift
% Refactored Project to support naming changes on LayoutAxis -> Axis

Thank you,
Francisco