### PR TITLE
Add a maxWidth parameter to LabelLayout

### DIFF
--- a/LayoutKit/Layouts/LabelLayout.swift
+++ b/LayoutKit/Layouts/LabelLayout.swift
@@ -25,6 +25,7 @@ public class LabelLayout: Layout {
     public let alignment: Alignment
     public let flexibility: Flexibility
     public let config: (UILabel -> Void)?
+    public let maxWidth: CGFloat
 
     private static let defaultNumberOfLines = 0
     private static let defaultFont = UIFont.systemFontOfSize(UIFont.labelFontSize())
@@ -36,6 +37,7 @@ public class LabelLayout: Layout {
                 font: UIFont = defaultFont,
                 alignment: Alignment = defaultAlignment,
                 flexibility: Flexibility = defaultFlexibility,
+                maxWidth: CGFloat = CGFloat.max,
                 config: (UILabel -> Void)? = nil) {
         
         self.textType = textType
@@ -43,6 +45,7 @@ public class LabelLayout: Layout {
         self.font = font
         self.alignment = alignment
         self.flexibility = flexibility
+        self.maxWidth = maxWidth
         self.config = config
     }
 
@@ -53,12 +56,14 @@ public class LabelLayout: Layout {
                             font: UIFont = defaultFont,
                             alignment: Alignment = defaultAlignment,
                             flexibility: Flexibility = defaultFlexibility,
+                            maxWidth: CGFloat = CGFloat.max,
                             config: (UILabel -> Void)? = nil) {
 
         self.init(textType: .unattributed(text),
                   numberOfLines: numberOfLines,
                   font: font, alignment: alignment,
                   flexibility: flexibility,
+                  maxWidth:  maxWidth,
                   config: config)
     }
 
@@ -67,20 +72,26 @@ public class LabelLayout: Layout {
                             font: UIFont = defaultFont,
                             alignment: Alignment = defaultAlignment,
                             flexibility: Flexibility = defaultFlexibility,
+                            maxWidth: CGFloat = CGFloat.max,
                             config: (UILabel -> Void)? = nil) {
 
         self.init(textType: .attributed(attributedText),
                   numberOfLines: numberOfLines,
                   font: font, alignment: alignment,
                   flexibility: flexibility,
+                  maxWidth:  maxWidth,
                   config: config)
     }
 
     // MARK: - Layout protocol
 
     public func measurement(within maxSize: CGSize) -> LayoutMeasurement {
-        let fittedSize = textSize(within: maxSize)
-        return LayoutMeasurement(layout: self, size: fittedSize.sizeDecreasedToSize(maxSize), maxSize: maxSize, sublayouts: [])
+        var sizeConstraint = maxSize
+        if maxWidth < maxSize.width {
+            sizeConstraint.width = maxWidth
+        }
+        let fittedSize = textSize(within: sizeConstraint)
+        return LayoutMeasurement(layout: self, size: fittedSize.sizeDecreasedToSize(sizeConstraint), maxSize: sizeConstraint, sublayouts: [])
     }
 
     private func textSize(within maxSize: CGSize) -> CGSize {

--- a/LayoutKitTests/LabelLayoutTests.swift
+++ b/LayoutKitTests/LabelLayoutTests.swift
@@ -70,7 +70,19 @@ class LabelLayoutTests: XCTestCase {
             testFont(UIFont.systemFontOfSize(CGFloat(fontSize)))
         }
     }
-
+    
+    func testSizeLimitSingleLine() {
+        let font = UIFont.systemFontOfSize(16)
+        let text = "To thine own self be true, and it must follow, as the night the day, thou canst not then be false to any man."
+        
+        let maxWidth: CGFloat = 50
+        let label = UILabel(text: text, font: font)
+        let layoutSize = LabelLayout(text: text, font: font, numberOfLines: 1, maxWidth: maxWidth).arrangement().frame.size
+        let expectedSize = CGSize(width: maxWidth, height: label.intrinsicContentSize().height)
+        XCTAssertTrue(label.intrinsicContentSize().width > maxWidth)
+        XCTAssertEqual(expectedSize, layoutSize)
+    }
+    
     func testAttributedTextDefaultFont() {
         let text = NSAttributedString(string: "Hello! 😄😄😄")
 


### PR DESCRIPTION
maxWidth limits the width of the Label.
The idea is that in scenario like:

StackHorizontal[Label1(max 100), Label2]

Label1 can use horizontal space up to 100 Label 2 can use all the available space. All the other rules of StackLayout apply like before.

If there are other ways to achieve with current architecture please let me know. Otherwise happy to add more tests around this.
