### PR TITLE
[Xcode] Supports Xcode 8 / Swift 2.3

### DIFF
--- a/LayoutKit.xcodeproj/project.pbxproj
+++ b/LayoutKit.xcodeproj/project.pbxproj
@@ -1266,6 +1266,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -1304,6 +1305,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
This build settings allows the frameworks to be built using Xcode 8 and Swift 2.3 As a bonus, a side-effect is that Carthage will continue to work when using Xcode 8.