### PR TITLE
Allow deletion of arrangedSubviews from StackView

### DIFF
--- a/LayoutKit/Views/StackView.swift
+++ b/LayoutKit/Views/StackView.swift
@@ -87,16 +87,7 @@ open class StackView: UIView {
      Deletes all subviews from the stack.
      */
     open func removeArrangedSubviews() {
-        arrangedSubviews.removeAll()
-        invalidateIntrinsicContentSize()
-        setNeedsLayout()
-    }
-
-    /**
-     Deletes all subviews from the stack.
-     */
-    open func removeArrangedSubviews() {
-        for subview in subviews {
+        for subview in arrangedSubviews {
             subview.removeFromSuperview()
         }
         arrangedSubviews.removeAll()

--- a/LayoutKit/Views/StackView.swift
+++ b/LayoutKit/Views/StackView.swift
@@ -83,6 +83,27 @@ open class StackView: UIView {
         setNeedsLayout()
     }
 
+    /**
+     Deletes all subviews from the stack.
+     */
+    open func removeArrangedSubviews() {
+        arrangedSubviews.removeAll()
+        invalidateIntrinsicContentSize()
+        setNeedsLayout()
+    }
+
+    /**
+     Deletes all subviews from the stack.
+     */
+    open func removeArrangedSubviews() {
+        for subview in subviews {
+            subview.removeFromSuperview()
+        }
+        arrangedSubviews.removeAll()
+        invalidateIntrinsicContentSize()
+        setNeedsLayout()
+    }
+
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
         return stackLayout.measurement(within: size).size
     }

--- a/LayoutKitTests/StackViewTests.swift
+++ b/LayoutKitTests/StackViewTests.swift
@@ -99,35 +99,22 @@ class StackViewTests: XCTestCase {
 
     /**
      This tests to make sure we can add subviews to the stack view, lay them out, then
-     remove them, then add them back again.
+     remove them.
      */
-    func testReusableStackView() {
+    func testRemoveArrangedSubviews() {
         let view1 = FixedSizeView(width: 7, height: 14)
         let view2 = FixedSizeView(width: 18, height: 18.5)
         let view3 = FixedSizeView(width: 33.5, height: 23)
 
-        let sv = StackView(axis: .vertical)
-        sv.addArrangedSubviews([view1, view2, view3])
+        let stackView = StackView(axis: .vertical)
 
-        var ics = sv.intrinsicContentSize
-        XCTAssertEqual(ics, CGSize(width: 33.5, height: CGFloat(14 + 18.5 + 23)))
+        stackView.addArrangedSubviews([view1, view2, view3])
+        XCTAssertEqual(stackView.intrinsicContentSize, CGSize(width: 33.5, height: CGFloat(14 + 18.5 + 23)))
+        XCTAssertEqual(stackView.subviews.count, 3)
 
-        sv.frame = CGRect(origin: .zero, size: ics)
-        sv.layoutIfNeeded()
-
-        XCTAssertEqual(view1.frame, CGRect(x: 0, y: 0, width: 33.5, height: 14))
-        XCTAssertEqual(view2.frame, CGRect(x: 0, y: 14, width: 33.5, height: 18.5))
-        XCTAssertEqual(view3.frame, CGRect(x: 0, y: CGFloat(14+18.5), width: 33.5, height: 23))
-
-        // Now let's remove the views and make sure they're removed
-        sv.removeArrangedSubviews()
-
-        ics = sv.intrinsicContentSize
-        XCTAssertEqual(ics, CGSize.zero)
-        XCTAssertEqual(sv.subviews.count, 0)
-
-        sv.frame = CGRect(origin: .zero, size: ics)
-        sv.layoutIfNeeded()
+        stackView.removeArrangedSubviews()
+        XCTAssertEqual(stackView.intrinsicContentSize, CGSize.zero)
+        XCTAssertEqual(stackView.subviews.count, 0)
     }
 
     func testUIStackViewAutomaticallyInvalidatesIntrinsicContentSizeWhenContentChanges() {

--- a/LayoutKitTests/StackViewTests.swift
+++ b/LayoutKitTests/StackViewTests.swift
@@ -119,27 +119,15 @@ class StackViewTests: XCTestCase {
         XCTAssertEqual(view2.frame, CGRect(x: 0, y: 14, width: 33.5, height: 18.5))
         XCTAssertEqual(view3.frame, CGRect(x: 0, y: CGFloat(14+18.5), width: 33.5, height: 23))
 
-        // Now let's remove the views
+        // Now let's remove the views and make sure they're removed
         sv.removeArrangedSubviews()
-
-        sv.frame = CGRect(origin: .zero, size: ics)
-        sv.layoutIfNeeded()
 
         ics = sv.intrinsicContentSize
         XCTAssertEqual(ics, CGSize.zero)
-
-        // Add them back
-        sv.addArrangedSubviews([view1, view2, view3])
-
-        ics = sv.intrinsicContentSize
-        XCTAssertEqual(ics, CGSize(width: 33.5, height: CGFloat(14 + 18.5 + 23)))
+        XCTAssertEqual(sv.subviews.count, 0)
 
         sv.frame = CGRect(origin: .zero, size: ics)
         sv.layoutIfNeeded()
-
-        XCTAssertEqual(view1.frame, CGRect(x: 0, y: 0, width: 33.5, height: 14))
-        XCTAssertEqual(view2.frame, CGRect(x: 0, y: 14, width: 33.5, height: 18.5))
-        XCTAssertEqual(view3.frame, CGRect(x: 0, y: CGFloat(14+18.5), width: 33.5, height: 23))
     }
 
     func testUIStackViewAutomaticallyInvalidatesIntrinsicContentSizeWhenContentChanges() {

--- a/LayoutKitTests/StackViewTests.swift
+++ b/LayoutKitTests/StackViewTests.swift
@@ -97,6 +97,51 @@ class StackViewTests: XCTestCase {
         ])
     }
 
+    /**
+     This tests to make sure we can add subviews to the stack view, lay them out, then
+     remove them, then add them back again.
+     */
+    func testReusableStackView() {
+        let view1 = FixedSizeView(width: 7, height: 14)
+        let view2 = FixedSizeView(width: 18, height: 18.5)
+        let view3 = FixedSizeView(width: 33.5, height: 23)
+
+        let sv = StackView(axis: .vertical)
+        sv.addArrangedSubviews([view1, view2, view3])
+
+        var ics = sv.intrinsicContentSize
+        XCTAssertEqual(ics, CGSize(width: 33.5, height: CGFloat(14 + 18.5 + 23)))
+
+        sv.frame = CGRect(origin: .zero, size: ics)
+        sv.layoutIfNeeded()
+
+        XCTAssertEqual(view1.frame, CGRect(x: 0, y: 0, width: 33.5, height: 14))
+        XCTAssertEqual(view2.frame, CGRect(x: 0, y: 14, width: 33.5, height: 18.5))
+        XCTAssertEqual(view3.frame, CGRect(x: 0, y: CGFloat(14+18.5), width: 33.5, height: 23))
+
+        // Now let's remove the views
+        sv.removeArrangedSubviews()
+
+        sv.frame = CGRect(origin: .zero, size: ics)
+        sv.layoutIfNeeded()
+
+        ics = sv.intrinsicContentSize
+        XCTAssertEqual(ics, CGSize.zero)
+
+        // Add them back
+        sv.addArrangedSubviews([view1, view2, view3])
+
+        ics = sv.intrinsicContentSize
+        XCTAssertEqual(ics, CGSize(width: 33.5, height: CGFloat(14 + 18.5 + 23)))
+
+        sv.frame = CGRect(origin: .zero, size: ics)
+        sv.layoutIfNeeded()
+
+        XCTAssertEqual(view1.frame, CGRect(x: 0, y: 0, width: 33.5, height: 14))
+        XCTAssertEqual(view2.frame, CGRect(x: 0, y: 14, width: 33.5, height: 18.5))
+        XCTAssertEqual(view3.frame, CGRect(x: 0, y: CGFloat(14+18.5), width: 33.5, height: 23))
+    }
+
     func testUIStackViewAutomaticallyInvalidatesIntrinsicContentSizeWhenContentChanges() {
         if #available(iOS 9.0, *) {
             let label = UILabel(text: "Nick", font: UIFont(name: "Helvetica", size: 17)!)

--- a/docs/uikit.md
+++ b/docs/uikit.md
@@ -21,7 +21,7 @@ LayoutKit is faster than Auto Layout by default so it is perfectly fine to not b
 
 ## UICollectionView and UITableView
 
-If you have a UICollectionView or UITableView and all of the cells use LayoutKit, then you can use [ReloadableViewLayoutAdapter](https://github.com/linkedin/LayoutKit/blob/master/LayoutKit/Views/ReloadableLayoutViewAdapter.swift) to automatically handle computing cell layouts on a background thread.
+If you have a UICollectionView or UITableView and all of the cells use LayoutKit, then you can use [ReloadableViewLayoutAdapter](https://github.com/linkedin/LayoutKit/blob/master/LayoutKit/Views/ReloadableViewLayoutAdapter.swift) to automatically handle computing cell layouts on a background thread.
 
 ## Mixing Auto Layout and LayoutKit
 


### PR DESCRIPTION
If an implementor wants to reuse the `StackView` with different subviews (like in a table view cell), currently, there's no way to delete the subviews, only a way to add more. This fix adds a remove method. Additionally, it fixes a documentation link.