### PR TITLE
Add `isLayoutKitView` for safe view removal

### DIFF
--- a/LayoutKit/ViewRecycler.swift
+++ b/LayoutKit/ViewRecycler.swift
@@ -41,7 +41,9 @@ class ViewRecycler {
             viewsById[viewReuseId] = nil
             return view
         }
+
         let providedView = viewProvider()
+        providedView.isLayoutKitView = true
 
         // Remove the provided view from the list of cached views.
         if let viewReuseId = providedView.viewReuseId, let oldView = viewsById[viewReuseId], oldView == providedView {
@@ -60,7 +62,7 @@ class ViewRecycler {
         }
         viewsById.removeAll()
 
-        for view in unidentifiedViews {
+        for view in unidentifiedViews where view.isLayoutKitView {
             view.removeFromSuperview()
         }
         unidentifiedViews.removeAll()
@@ -68,6 +70,7 @@ class ViewRecycler {
 }
 
 private var viewReuseIdKey: UInt8 = 0
+private var isLayoutKitViewKey: UInt8 = 0
 
 extension View {
 
@@ -86,6 +89,16 @@ extension View {
         }
         set {
             objc_setAssociatedObject(self, &viewReuseIdKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+
+    /// Indicates the view is managed by LayoutKit that can be safely removed.
+    fileprivate var isLayoutKitView: Bool {
+        get {
+            return (objc_getAssociatedObject(self, &isLayoutKitViewKey) as? NSNumber)?.boolValue ?? false
+        }
+        set {
+            objc_setAssociatedObject(self, &isLayoutKitViewKey, NSNumber(value: newValue), .OBJC_ASSOCIATION_RETAIN)
         }
     }
 }

--- a/LayoutKit/ViewRecycler.swift
+++ b/LayoutKit/ViewRecycler.swift
@@ -93,7 +93,7 @@ extension View {
     }
 
     /// Indicates the view is managed by LayoutKit that can be safely removed.
-    fileprivate var isLayoutKitView: Bool {
+    var isLayoutKitView: Bool {
         get {
             return (objc_getAssociatedObject(self, &isLayoutKitViewKey) as? NSNumber)?.boolValue ?? false
         }

--- a/LayoutKitTests/ViewRecyclerTests.swift
+++ b/LayoutKitTests/ViewRecyclerTests.swift
@@ -11,9 +11,10 @@ import XCTest
 
 class ViewRecyclerTests: XCTestCase {
 
-    func testNilIdNotRecycled() {
+    func testNilIdNotRecycledAndNotRemoved() {
         let root = View()
         let zero = View()
+        zero.isLayoutKitView = false    // default
         root.addSubview(zero)
 
         let recycler = ViewRecycler(rootView: root)
@@ -24,7 +25,24 @@ class ViewRecyclerTests: XCTestCase {
         XCTAssertEqual(v, expectedView)
 
         recycler.purgeViews()
-        XCTAssertNil(zero.superview)
+        XCTAssertNotNil(zero.superview, "`zero` should not be removed because `isLayoutKitView` is false")
+    }
+
+    func testNilIdNotRecycledAndRemoved() {
+        let root = View()
+        let zero = View()
+        zero.isLayoutKitView = true // requires this flag to be removed by `ViewRecycler`
+        root.addSubview(zero)
+
+        let recycler = ViewRecycler(rootView: root)
+        let expectedView = View()
+        let v: View? = recycler.makeOrRecycleView(havingViewReuseId: nil, viewProvider: {
+            return expectedView
+        })
+        XCTAssertEqual(v, expectedView)
+
+        recycler.purgeViews()
+        XCTAssertNil(zero.superview, "`zero` should be removed")
     }
 
     func testNonNilIdRecycled() {

--- a/LayoutKitTests/ViewRecyclerTests.swift
+++ b/LayoutKitTests/ViewRecyclerTests.swift
@@ -93,6 +93,7 @@ class ViewRecyclerTests: XCTestCase {
 
     /// Test for safe subview-purge in composite view e.g. UIButton.
     /// - SeeAlso: https://github.com/linkedin/LayoutKit/pull/85
+    #if os(iOS) || os(tvOS)
     func testRecycledCompositeView() {
         let root = View()
         let button = UIButton(viewReuseId: "1")
@@ -114,6 +115,7 @@ class ViewRecyclerTests: XCTestCase {
         XCTAssertNotNil(button.superview)
         XCTAssertEqual(button.subviews.count, 1, "UIButton's subviews should not be removed by `recycler`")
     }
+    #endif
 }
 
 extension View {


### PR DESCRIPTION
It seems composite view's subviews e.g. `UIButton`'s subviews (`UIImageView` and `UIButtonLabel`) gets removed and displays nothing when:
	
1.`makeViews` is called twice
2. ButtonLayout has `viewReuseId` (UIButton will be reused) 

This is because `purgeViews` is removing views even though some of them are not managed by LayoutKit, so I added `isLayoutKitView` for safe view removal.