### PR TITLE
Making Layout Adapter's queue public

### DIFF
--- a/LayoutKit/Views/ReloadableViewLayoutAdapter.swift
+++ b/LayoutKit/Views/ReloadableViewLayoutAdapter.swift
@@ -22,7 +22,7 @@ open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDel
     open internal(set) var currentArrangement = [Section<[LayoutArrangement]>]()
 
     /// The queue that layouts are computed on.
-    let backgroundLayoutQueue: OperationQueue = {
+    public let backgroundLayoutQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.name = String(describing: ReloadableViewLayoutAdapter.self)
         // The queue is serial so we can do streaming properly.


### PR DESCRIPTION
Making the backgroundLayoutQueue property in ReloadableViewLayoutAdapter public will help us get a reference of the underlying queue on which we can retrieve our Realm objects.
Fixes #104 