### PR TITLE
Fix/crash in sampleapp

### DIFF
--- a/LayoutKitSampleApp/Benchmarks/BenchmarkViewController.swift
+++ b/LayoutKitSampleApp/Benchmarks/BenchmarkViewController.swift
@@ -17,7 +17,7 @@ class BenchmarkViewController: UITableViewController {
         ViewControllerData(title: "UICollectionView UIStack feed", factoryBlock: { viewCount in
             if #available(iOS 9.0, *) {
                 let data = FeedItemData.generate(count: viewCount)
-                return CollectionViewController<FeedItemUIStackView>(data: data)
+                return CollectionViewController(data: data, contentViewClass: FeedItemUIStackView.self)
             } else {
                 NSLog("UIStackView only supported on iOS 9+")
                 return nil
@@ -26,23 +26,23 @@ class BenchmarkViewController: UITableViewController {
 
         ViewControllerData(title: "UICollectionView Auto Layout feed", factoryBlock: { viewCount in
             let data = FeedItemData.generate(count: viewCount)
-            return CollectionViewController<FeedItemAutoLayoutView>(data: data)
+            return CollectionViewController(data: data, contentViewClass: FeedItemAutoLayoutView.self)
         }),
 
         ViewControllerData(title: "UICollectionView LayoutKit feed", factoryBlock: { viewCount in
             let data = FeedItemData.generate(count: viewCount)
-            return CollectionViewController<FeedItemLayoutKitView>(data: data)
+            return CollectionViewController(data: data, contentViewClass: FeedItemLayoutKitView.self)
         }),
 
         ViewControllerData(title: "UICollectionView Manual Layout feed", factoryBlock: { viewCount in
             let data = FeedItemData.generate(count: viewCount)
-            return CollectionViewController<FeedItemManualView>(data: data)
+            return CollectionViewController(data: data, contentViewClass: FeedItemManualView.self)
         }),
 
         ViewControllerData(title: "UITableView UIStack feed", factoryBlock: { viewCount in
             if #available(iOS 9.0, *) {
                 let data = FeedItemData.generate(count: viewCount)
-                return TableViewController<FeedItemUIStackView>(data: data)
+                return TableViewController(data: data, contentViewClass: FeedItemUIStackView.self)
             } else {
                 NSLog("UIStackView only supported on iOS 9+")
                 return nil
@@ -51,17 +51,17 @@ class BenchmarkViewController: UITableViewController {
 
         ViewControllerData(title: "UITableView Auto Layout feed", factoryBlock: { viewCount in
             let data = FeedItemData.generate(count: viewCount)
-            return TableViewController<FeedItemAutoLayoutView>(data: data)
+            return TableViewController(data: data, contentViewClass: FeedItemAutoLayoutView.self)
         }),
 
         ViewControllerData(title: "UITableView LayoutKit feed", factoryBlock: { viewCount in
             let data = FeedItemData.generate(count: viewCount)
-            return TableViewController<FeedItemLayoutKitView>(data: data)
+            return TableViewController(data: data, contentViewClass: FeedItemLayoutKitView.self)
         }),
 
         ViewControllerData(title: "UITableView Manual Layout feed", factoryBlock: { viewCount in
             let data = FeedItemData.generate(count: viewCount)
-            return TableViewController<FeedItemManualView>(data: data)
+            return TableViewController(data: data, contentViewClass: FeedItemLayoutKitView.self)
         })
     ]
 

--- a/LayoutKitSampleApp/Benchmarks/DataBinder.swift
+++ b/LayoutKitSampleApp/Benchmarks/DataBinder.swift
@@ -6,9 +6,37 @@
 // software distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
-import Foundation
+import UIKit
 
 protocol DataBinder {
-    associatedtype DataType
-    func setData(_ data: DataType)
+    func setData(_ data: FeedItemData)
+}
+
+enum DataBinderHelper {
+    static func setData(_ data: FeedItemData, forView view: UIView) {
+
+        if let feedItemAutoLayoutView = view as? FeedItemAutoLayoutView {
+            feedItemAutoLayoutView.setData(data)
+            return
+        }
+
+        if let feedItemManualView = view as? FeedItemManualView {
+            feedItemManualView.setData(data)
+            return
+        }
+
+        if let feedItemLayoutKitView = view as? FeedItemLayoutKitView {
+            feedItemLayoutKitView.setData(data)
+            return
+        }
+
+        if #available(iOS 9.0, *) {
+            if let feedItemUIStackView = view as? FeedItemUIStackView {
+                feedItemUIStackView.setData(data)
+                return
+            }
+        }
+
+        assertionFailure("Unknown type of the view")
+    }
 }

--- a/LayoutKitSampleApp/Benchmarks/DataBinder.swift
+++ b/LayoutKitSampleApp/Benchmarks/DataBinder.swift
@@ -13,6 +13,13 @@ protocol DataBinder {
 }
 
 enum DataBinderHelper {
+
+    /// Before v4.0.2, `CollectionViewController` and `TableViewController` are using generics.
+    /// `DWURecycling` will use method swizzling to replace some `UIcollectionView` and `UITableView`
+    /// data source methods and inject label to the cells.
+    /// By using different ContentView, `TableViewController` and `CollectionViewController` will be
+    /// treated differently. That means the correct method swizzling is only done correctly for the for
+    /// time. The solution to remove generic is a fix to https://github.com/linkedin/LayoutKit/issues/103
     static func setData(_ data: FeedItemData, forView view: UIView) {
 
         if let feedItemAutoLayoutView = view as? FeedItemAutoLayoutView {


### PR DESCRIPTION
- DWU library will replace the implementation of `cellForIndexPath` for `UITableView` and `UICollectionView`.
- Using generic of `CollectionViewController` will cause the unstable of DWU method swizzling since `CollectionViewController` will have different address because of different generic types
- `TableViewController` is working because `menuViewController` will have method swizzling for the super class at the beginning.
- To fix crash, I can think of three ways
  - Removed method swizzling (That will be hard to inject label to `LayoutKit` and implementation has to be modified.)
  - Removed generics (That's the best solution I can come with. The cons is to make the class not clean as generic one)
  - Fixing the logic in DWU (It may resolve for this time, but it might be broken again in the future if Apple changes anything on generics)