### PR TITLE
Removed pre-install scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ osx_image: xcode8.3
 script: sh build.sh /tmp/LayoutKit
 after_success:
   - bash <(curl -s https://codecov.io/bash) -D /tmp/LayoutKit
-before_install:
-  - xcrun simctl delete 22FA2149-1241-469C-BF6D-462D3837DB72
-  - xcrun simctl delete 8188B40E-F57F-4519-AC47-E43D884B9016


### PR DESCRIPTION
The current build script causes the error as below,
```
$ xcrun simctl delete 22FA2149-1241-469C-BF6D-462D3837DB72
Invalid device: 22FA2149-1241-469C-BF6D-462D3837DB72
The command "xcrun simctl delete 22FA2149-1241-469C-BF6D-462D3837DB72" failed and exited with 162 during .
```