### PR TITLE
Open ReloadableViewLayoutAdapter UIKit implementations

### DIFF
--- a/LayoutKit.xcodeproj/project.pbxproj
+++ b/LayoutKit.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		44F968181E4263DC00392763 /* TextViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F968161E42639500392763 /* TextViewLayoutTests.swift */; };
 		44F968191E4263DC00392763 /* TextViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F968161E42639500392763 /* TextViewLayoutTests.swift */; };
 		44F9681A1E42640400392763 /* TextViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F968141E425F5D00392763 /* TextViewLayout.swift */; };
+		AD2C36441EA5AFB500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2C36421EA5AF9500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -386,6 +387,7 @@
 		448CEC0E1E4E0CB500F8AD9E /* TextViewDefaultFont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewDefaultFont.swift; sourceTree = "<group>"; };
 		44F968141E425F5D00392763 /* TextViewLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewLayout.swift; sourceTree = "<group>"; };
 		44F968161E42639500392763 /* TextViewLayoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewLayoutTests.swift; sourceTree = "<group>"; };
+		AD2C36421EA5AF9500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -565,6 +567,7 @@
 				0BCB76581D8725310065E02A /* LabelLayoutTests.swift */,
 				0BCB76591D8725310065E02A /* LayoutArrangementTests.swift */,
 				0BCB765C1D8725310065E02A /* ReloadableViewLayoutAdapterCollectionViewTests.swift */,
+				AD2C36421EA5AF9500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift */,
 				0BCB765D1D8725310065E02A /* ReloadableViewLayoutAdapterTableViewTests.swift */,
 				0BCB765E1D8725310065E02A /* ReloadableViewLayoutAdapterTestCase.swift */,
 				0BDDF95A1E25ACCE008B0A6F /* ReloadableViewTests.swift */,
@@ -1053,6 +1056,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AD2C36441EA5AFB500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift in Sources */,
 				0B765F301DC135B8000BF1FD /* CGFloatExtensionTests.swift in Sources */,
 				0B2D092C1D872F75007E487C /* ReloadableViewLayoutAdapterCollectionViewTests.swift in Sources */,
 				0B2D092E1D872F75007E487C /* ReloadableViewLayoutAdapterTestCase.swift in Sources */,

--- a/LayoutKit.xcodeproj/project.pbxproj
+++ b/LayoutKit.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		44F968191E4263DC00392763 /* TextViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F968161E42639500392763 /* TextViewLayoutTests.swift */; };
 		44F9681A1E42640400392763 /* TextViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F968141E425F5D00392763 /* TextViewLayout.swift */; };
 		AD2C36441EA5AFB500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2C36421EA5AF9500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift */; };
+		ADE5FCC11EA5B5F3006A3DC2 /* ReloadableViewLayoutAdapterTableViewOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE5FCBF1EA5B5C8006A3DC2 /* ReloadableViewLayoutAdapterTableViewOverrideTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -388,6 +389,7 @@
 		44F968141E425F5D00392763 /* TextViewLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewLayout.swift; sourceTree = "<group>"; };
 		44F968161E42639500392763 /* TextViewLayoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewLayoutTests.swift; sourceTree = "<group>"; };
 		AD2C36421EA5AF9500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift; sourceTree = "<group>"; };
+		ADE5FCBF1EA5B5C8006A3DC2 /* ReloadableViewLayoutAdapterTableViewOverrideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReloadableViewLayoutAdapterTableViewOverrideTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -569,6 +571,7 @@
 				0BCB765C1D8725310065E02A /* ReloadableViewLayoutAdapterCollectionViewTests.swift */,
 				AD2C36421EA5AF9500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift */,
 				0BCB765D1D8725310065E02A /* ReloadableViewLayoutAdapterTableViewTests.swift */,
+				ADE5FCBF1EA5B5C8006A3DC2 /* ReloadableViewLayoutAdapterTableViewOverrideTests.swift */,
 				0BCB765E1D8725310065E02A /* ReloadableViewLayoutAdapterTestCase.swift */,
 				0BDDF95A1E25ACCE008B0A6F /* ReloadableViewTests.swift */,
 				0BCB765F1D8725310065E02A /* SizeLayoutTests.swift */,
@@ -1056,6 +1059,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ADE5FCC11EA5B5F3006A3DC2 /* ReloadableViewLayoutAdapterTableViewOverrideTests.swift in Sources */,
 				AD2C36441EA5AFB500550A03 /* ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift in Sources */,
 				0B765F301DC135B8000BF1FD /* CGFloatExtensionTests.swift in Sources */,
 				0B2D092C1D872F75007E487C /* ReloadableViewLayoutAdapterCollectionViewTests.swift in Sources */,

--- a/LayoutKitTests/ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift
+++ b/LayoutKitTests/ReloadableViewLayoutAdapterCollectionViewOverrideTests.swift
@@ -1,0 +1,67 @@
+// Copyright 2016 LinkedIn Corp.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+import XCTest
+@testable import LayoutKit
+
+class ReloadableViewLayoutAdapterCollectionViewOverrideTests: XCTestCase {
+
+    var reloadableViewLayoutAdapter: MockReloadableCollectionViewAdapter!
+    var collectionView: UICollectionView!
+
+    override func setUp() {
+        collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
+        reloadableViewLayoutAdapter = MockReloadableCollectionViewAdapter(reloadableView: collectionView)
+    }
+
+    func testSizeForItemAt_Called_ShouldCallMock() {
+        _ = reloadableViewLayoutAdapter.collectionView(collectionView, layout: UICollectionViewFlowLayout(), sizeForItemAt: IndexPath(item: 0, section: 0))
+
+        XCTAssert(reloadableViewLayoutAdapter.collectionViewSizeForItemAtCallCount == 1)
+    }
+
+
+    func testCellForItemAt_Called_ShouldCallMock() {
+        _ = reloadableViewLayoutAdapter.collectionView(collectionView, cellForItemAt: IndexPath(row: 0, section: 0))
+
+        XCTAssert(reloadableViewLayoutAdapter.collectionViewCellForItemAtCallCount == 1)
+    }
+
+    func testViewForSupplementaryElementOfKind_Called_ShouldCallMock() {
+        _ = reloadableViewLayoutAdapter.collectionView(collectionView, viewForSupplementaryElementOfKind: "", at: IndexPath(row: 0, section: 0))
+
+        XCTAssert(reloadableViewLayoutAdapter.collectionViewViewForSupplementaryElementOfKindCallCount == 1)
+    }
+}
+
+class MockReloadableCollectionViewAdapter: ReloadableViewLayoutAdapter {
+
+    var collectionViewSizeForItemAtCallCount = 0
+
+    override func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        collectionViewSizeForItemAtCallCount += 1
+
+        return CGSize.zero
+    }
+
+    var collectionViewCellForItemAtCallCount = 0
+
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        collectionViewCellForItemAtCallCount += 1
+
+        return UICollectionViewCell()
+    }
+
+    var collectionViewViewForSupplementaryElementOfKindCallCount = 0
+
+    override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        collectionViewViewForSupplementaryElementOfKindCallCount += 1
+
+        return UICollectionReusableView()
+    }
+}

--- a/LayoutKitTests/ReloadableViewLayoutAdapterTableViewOverrideTests.swift
+++ b/LayoutKitTests/ReloadableViewLayoutAdapterTableViewOverrideTests.swift
@@ -1,0 +1,67 @@
+// Copyright 2016 LinkedIn Corp.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+import XCTest
+@testable import LayoutKit
+
+class ReloadableViewLayoutAdapterTableViewOverrideTests: XCTestCase {
+
+    var reloadableViewLayoutAdapter: MockReloadableTableViewAdapter!
+    var tableView: UITableView!
+
+    override func setUp() {
+        tableView = UITableView()
+        reloadableViewLayoutAdapter = MockReloadableTableViewAdapter(reloadableView: tableView)
+    }
+
+    func testCellForRowAt_Called_ShouldCallMock() {
+        _ = reloadableViewLayoutAdapter.tableView(tableView, cellForRowAt: IndexPath(item: 0, section: 0))
+
+        XCTAssert(reloadableViewLayoutAdapter.tableViewCellForRowAtCallCount == 1)
+    }
+
+
+    func testNumberOfRowsInSection_Called_ShouldCallMock() {
+        _ = reloadableViewLayoutAdapter.tableView(tableView, numberOfRowsInSection: 0)
+
+        XCTAssert(reloadableViewLayoutAdapter.tableViewNumberOfRowsInSectionCallCount == 1)
+    }
+
+    func testHeightForFooterInSection_Called_ShouldCallMock() {
+        _ = reloadableViewLayoutAdapter.tableView(tableView, heightForFooterInSection: 0)
+
+        XCTAssert(reloadableViewLayoutAdapter.tableViewHeightForFooterInSectionCallCount == 1)
+    }
+}
+
+class MockReloadableTableViewAdapter: ReloadableViewLayoutAdapter {
+
+    var tableViewHeightForFooterInSectionCallCount = 0
+
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        tableViewHeightForFooterInSectionCallCount += 1
+
+        return 0
+    }
+
+    var tableViewNumberOfRowsInSectionCallCount = 0
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        tableViewNumberOfRowsInSectionCallCount += 1
+
+        return 0
+    }
+
+    var tableViewCellForRowAtCallCount = 0
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        tableViewCellForRowAtCallCount += 1
+
+        return UITableViewCell()
+    }
+}

--- a/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
@@ -12,15 +12,15 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.size
     }
 
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return currentArrangement[section].header?.frame.size ?? .zero
     }
 
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return currentArrangement[section].footer?.frame.size ?? .zero
     }
 }
@@ -29,11 +29,11 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
     
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 
-    public func numberOfSections(in collectionView: UICollectionView) -> Int {
+    open func numberOfSections(in collectionView: UICollectionView) -> Int {
         return currentArrangement.count
     }
 
@@ -44,7 +44,7 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
         return cell
     }
 
-    public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    open func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: reuseIdentifier, for: indexPath)
         let arrangement: LayoutArrangement?
         switch kind {

--- a/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
@@ -12,14 +12,17 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.size
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return currentArrangement[section].header?.frame.size ?? .zero
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return currentArrangement[section].footer?.frame.size ?? .zero
     }
@@ -28,15 +31,18 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 // MARK: - UICollectionViewDataSource
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
-    
+
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func numberOfSections(in collectionView: UICollectionView) -> Int {
         return currentArrangement.count
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
@@ -44,6 +50,7 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
         return cell
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: reuseIdentifier, for: indexPath)
         let arrangement: LayoutArrangement?

--- a/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
@@ -12,17 +12,17 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.size
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return currentArrangement[section].header?.frame.size ?? .zero
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return currentArrangement[section].footer?.frame.size ?? .zero
     }
@@ -32,17 +32,17 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func numberOfSections(in collectionView: UICollectionView) -> Int {
         return currentArrangement.count
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
@@ -50,7 +50,7 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
         return cell
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: reuseIdentifier, for: indexPath)
         let arrangement: LayoutArrangement?

--- a/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
@@ -12,17 +12,17 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.size
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return currentArrangement[section].header?.frame.size ?? .zero
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return currentArrangement[section].footer?.frame.size ?? .zero
     }
@@ -32,17 +32,17 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDelegateFlowLayout {
 
 extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func numberOfSections(in collectionView: UICollectionView) -> Int {
         return currentArrangement.count
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
@@ -50,7 +50,7 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
         return cell
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: reuseIdentifier, for: indexPath)
         let arrangement: LayoutArrangement?

--- a/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UICollectionView.swift
@@ -37,7 +37,7 @@ extension ReloadableViewLayoutAdapter: UICollectionViewDataSource {
         return currentArrangement.count
     }
 
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
         item.makeViews(in: cell.contentView)

--- a/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
@@ -12,27 +12,27 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.height
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return currentArrangement[section].header?.frame.height ?? 0
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return currentArrangement[section].footer?.frame.height ?? 0
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].header, tableView: tableView)
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].footer, tableView: tableView)
     }
@@ -59,17 +59,17 @@ extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
 extension ReloadableViewLayoutAdapter: UITableViewDataSource {
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func numberOfSections(in tableView: UITableView) -> Int {
         return currentArrangement.count
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 
-    /// - Warning: Not calling super may result in unexpected behaviour
+    /// - Warning: Subclasses that override this method must call super
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)

--- a/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
@@ -12,27 +12,27 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.height
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return currentArrangement[section].header?.frame.height ?? 0
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return currentArrangement[section].footer?.frame.height ?? 0
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].header, tableView: tableView)
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].footer, tableView: tableView)
     }
@@ -59,17 +59,17 @@ extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
 extension ReloadableViewLayoutAdapter: UITableViewDataSource {
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func numberOfSections(in tableView: UITableView) -> Int {
         return currentArrangement.count
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 
-    /// - Attention: Not calling super may result in unexpected behaviour
+    /// - Warning: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)

--- a/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
@@ -12,22 +12,27 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.height
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return currentArrangement[section].header?.frame.height ?? 0
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return currentArrangement[section].footer?.frame.height ?? 0
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].header, tableView: tableView)
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].footer, tableView: tableView)
     }
@@ -54,14 +59,17 @@ extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
 extension ReloadableViewLayoutAdapter: UITableViewDataSource {
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func numberOfSections(in tableView: UITableView) -> Int {
         return currentArrangement.count
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 
+    /// - Attention: Not calling super may result in unexpected behaviour
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)

--- a/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
@@ -12,23 +12,23 @@ import UIKit
 
 extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
-    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return currentArrangement[indexPath.section].items[indexPath.item].frame.height
     }
 
-    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return currentArrangement[section].header?.frame.height ?? 0
     }
 
-    public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return currentArrangement[section].footer?.frame.height ?? 0
     }
 
-    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].header, tableView: tableView)
     }
 
-    public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         return renderLayout(currentArrangement[section].footer, tableView: tableView)
     }
 
@@ -54,11 +54,11 @@ extension ReloadableViewLayoutAdapter: UITableViewDelegate {
 
 extension ReloadableViewLayoutAdapter: UITableViewDataSource {
 
-    public func numberOfSections(in tableView: UITableView) -> Int {
+    open func numberOfSections(in tableView: UITableView) -> Int {
         return currentArrangement.count
     }
 
-    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return currentArrangement[section].items.count
     }
 

--- a/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
@@ -62,7 +62,7 @@ extension ReloadableViewLayoutAdapter: UITableViewDataSource {
         return currentArrangement[section].items.count
     }
 
-    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = currentArrangement[indexPath.section].items[indexPath.item]
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
         item.makeViews(in: cell.contentView)


### PR DESCRIPTION
Making ReloadableViewLayoutAdapter UIKit implementations (UITableViewDelegate, UITableViewDataSource, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource) open in order to allow for easy customisation of default behaviour.

This allows for potentially breaking overrides of given methods. Unfortunately, Swift currently does not have something like `__attribute((objc_requires_super))`. That being said, I think this change is still beneficial.

Fixes #128