### PR TITLE
Open ReloadableView UITableView and UICollectionView implementations

### DIFF
--- a/LayoutKitTests/ReloadableViewTests.swift
+++ b/LayoutKitTests/ReloadableViewTests.swift
@@ -10,7 +10,9 @@ import XCTest
 import LayoutKit // intentionally not @testable
 
 class ReloadableViewTests: XCTestCase {
-    
+
+    // MARK: collection view
+
     func testCanOverrideCollectionViewRegisterViews() {
         let registerViewsCollectionView = RegisterViewsCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         registerViewsCollectionView.registerViewsExpectation = expectation(description: "registerViews")
@@ -22,6 +24,30 @@ class ReloadableViewTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
+    func testCanOverride_CollectionView_PerformBatchUpdates() {
+        let registerViewsCollectionView = RegisterViewsCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        registerViewsCollectionView.reloadDataSynchronouslyExpectation = expectation(description: "reloadDataSynchronously")
+
+        // upcast to UITableView to make sure that overloading works correctly
+        let collectionView: UICollectionView = registerViewsCollectionView
+        collectionView.reloadDataSynchronously()
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testCanOverride_CollectionView_ReloadDataSynchronouslyExpectation() {
+        let registerViewsCollectionView = RegisterViewsCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        registerViewsCollectionView.performExpectation = expectation(description: "perform")
+
+        // upcast to UITableView to make sure that overloading works correctly
+        let collectionView: UICollectionView = registerViewsCollectionView
+        collectionView.perform(batchUpdates: BatchUpdates())
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+
+    // MARK: table view
 
     func testCanOverrideTableViewRegisterViews() {
         let registerViewsTableView = RegisterViewsTableView(frame: .zero)
@@ -30,6 +56,28 @@ class ReloadableViewTests: XCTestCase {
         // upcast to UITableView to make sure that overloading works correctly
         let tableView: UITableView = registerViewsTableView
         tableView.registerViews(withReuseIdentifier: "reuseIdentifier")
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testCanOverride_PerformBatchUpdates() {
+        let registerViewsTableView = RegisterViewsTableView(frame: .zero)
+        registerViewsTableView.reloadDataSynchronouslyExpectation = expectation(description: "reloadDataSynchronously")
+
+        // upcast to UITableView to make sure that overloading works correctly
+        let tableView: UITableView = registerViewsTableView
+        tableView.reloadDataSynchronously()
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testCanOverride_ReloadDataSynchronouslyExpectation() {
+        let registerViewsTableView = RegisterViewsTableView(frame: .zero)
+        registerViewsTableView.performExpectation = expectation(description: "perform")
+
+        // upcast to UITableView to make sure that overloading works correctly
+        let tableView: UITableView = registerViewsTableView
+        tableView.perform(batchUpdates: BatchUpdates())
 
         waitForExpectations(timeout: 10.0, handler: nil)
     }
@@ -42,6 +90,18 @@ class RegisterViewsCollectionView: UICollectionView {
     override func registerViews(withReuseIdentifier reuseIdentifier: String) {
         registerViewsExpectation?.fulfill()
     }
+
+    var reloadDataSynchronouslyExpectation: XCTestExpectation?
+
+    override func reloadDataSynchronously() {
+        reloadDataSynchronouslyExpectation?.fulfill()
+    }
+
+    var performExpectation: XCTestExpectation?
+
+    override func perform(batchUpdates: BatchUpdates) {
+        performExpectation?.fulfill()
+    }
 }
 
 class RegisterViewsTableView: UITableView {
@@ -50,5 +110,17 @@ class RegisterViewsTableView: UITableView {
 
     override func registerViews(withReuseIdentifier reuseIdentifier: String) {
         registerViewsExpectation?.fulfill()
+    }
+
+    var reloadDataSynchronouslyExpectation: XCTestExpectation?
+
+    override func reloadDataSynchronously() {
+        reloadDataSynchronouslyExpectation?.fulfill()
+    }
+
+    var performExpectation: XCTestExpectation?
+
+    override func perform(batchUpdates: BatchUpdates) {
+        performExpectation?.fulfill()
     }
 }

--- a/LayoutKitTests/ReloadableViewTests.swift
+++ b/LayoutKitTests/ReloadableViewTests.swift
@@ -28,7 +28,7 @@ class ReloadableViewTests: XCTestCase {
         let registerViewsCollectionView = RegisterViewsCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         registerViewsCollectionView.reloadDataSynchronouslyExpectation = expectation(description: "reloadDataSynchronously")
 
-        // upcast to UITableView to make sure that overloading works correctly
+        // upcast to UICollectionView to make sure that overloading works correctly
         let collectionView: UICollectionView = registerViewsCollectionView
         collectionView.reloadDataSynchronously()
 
@@ -39,7 +39,7 @@ class ReloadableViewTests: XCTestCase {
         let registerViewsCollectionView = RegisterViewsCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         registerViewsCollectionView.performExpectation = expectation(description: "perform")
 
-        // upcast to UITableView to make sure that overloading works correctly
+        // upcast to UICollectionView to make sure that overloading works correctly
         let collectionView: UICollectionView = registerViewsCollectionView
         collectionView.perform(batchUpdates: BatchUpdates())
 

--- a/Sources/Views/BatchUpdates.swift
+++ b/Sources/Views/BatchUpdates.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 /// A set of updates to apply to a `ReloadableView`.
-public struct BatchUpdates {
+public class BatchUpdates: NSObject {
     public var insertItems = [IndexPath]()
     public var deleteItems = [IndexPath]()
     public var reloadItems = [IndexPath]()
@@ -21,7 +21,9 @@ public struct BatchUpdates {
     public var reloadSections = IndexSet()
     public var moveSections = [SectionMove]()
 
-    public init() { }
+    public override init() {
+        super.init()
+    }
 }
 
 /// Instruction to move an item from one index path to another.

--- a/Sources/Views/BatchUpdates.swift
+++ b/Sources/Views/BatchUpdates.swift
@@ -9,7 +9,12 @@
 import Foundation
 
 
-/// A set of updates to apply to a `ReloadableView`.
+/**
+ A set of updates to apply to a `ReloadableView`.
+ 
+ Inherits from NSObject in order to be exposable to Objective-C.
+ Objective-C exposability is needed in order to override methods from extensions that use `BatchUpdates` as parameter.
+ */
 public class BatchUpdates: NSObject {
     public var insertItems = [IndexPath]()
     public var deleteItems = [IndexPath]()

--- a/Sources/Views/ReloadableView.swift
+++ b/Sources/Views/ReloadableView.swift
@@ -49,7 +49,7 @@ public protocol ReloadableView: class {
 /// Make UICollectionView conform to ReloadableView protocol.
 extension UICollectionView: ReloadableView {
 
-    public func reloadDataSynchronously() {
+    open func reloadDataSynchronously() {
         reloadData()
 
         // Force a layout so that it is safe to call insert after this.
@@ -62,7 +62,7 @@ extension UICollectionView: ReloadableView {
         register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionFooter, withReuseIdentifier: reuseIdentifier)
     }
 
-    public func perform(batchUpdates: BatchUpdates) {
+    open func perform(batchUpdates: BatchUpdates) {
         performBatchUpdates({
             if batchUpdates.insertItems.count > 0 {
                 self.insertItems(at: batchUpdates.insertItems)
@@ -98,7 +98,7 @@ extension UICollectionView: ReloadableView {
 /// Make UITableView conform to ReloadableView protocol.
 extension UITableView: ReloadableView {
 
-    public func reloadDataSynchronously() {
+    open func reloadDataSynchronously() {
         reloadData()
     }
 
@@ -107,7 +107,7 @@ extension UITableView: ReloadableView {
         register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: reuseIdentifier)
     }
 
-    public func perform(batchUpdates: BatchUpdates) {
+    open func perform(batchUpdates: BatchUpdates) {
         beginUpdates()
 
         // Update items.


### PR DESCRIPTION
Making implementation of methods `func reloadDataSynchronously()` and `func perform(batchUpdates: BatchUpdates)` open in order to simplify behaviour modification.

In order to be able to override methods declared in extensions, those methods need to be exposable to objc. In order to do so, `BatchUpdates` was changed to `class` and inherited `NSObject`.

Fixes #124