### PR TITLE
Fix ci builder

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Test building sample app" &&
+echo "Run building sample app" &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean build \
     -project LayoutKit.xcodeproj \
@@ -64,7 +64,7 @@ cat build.log | sh debug-time-function-bodies.sh &&
 
 # Test Cocopods, Carthage, Swift Package Management
 
-echo "Test building an iOS empty project with cocoapods" &&
+echo "Run building an iOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/ios &&
 pod install &&
@@ -80,7 +80,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh
 
-echo "Test build a macOS empty project with cocoapods" &&
+echo "Run building a macOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/macos &&
 pod install &&
@@ -95,7 +95,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh
 
-echo "Test building a tvOS empty project with cocoapods" &&
+echo "Run building a tvOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/tvos &&
 pod install &&

--- a/build.sh
+++ b/build.sh
@@ -5,11 +5,7 @@
 DERIVED_DATA=${1:-/tmp/LayoutKit}
 echo "Derived data location: $DERIVED_DATA";
 
-    #-destination 'platform=iOS Simulator,name=iPhone 6,OS=8.4' \
-    #-destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=8.4' \
-
 set -o pipefail &&
-instruments -s devices &&
 
 echo "Run tests on iOS" &&
 rm -rf $DERIVED_DATA &&

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ time xcodebuild clean build \
     | tee ../../../build.log \
     | xcpretty &&
 cd ../../.. &&
-cat build.log | sh debug-time-function-bodies.sh
+cat build.log | sh debug-time-function-bodies.sh &&
 
 echo "Run building a macOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&
@@ -93,7 +93,7 @@ time xcodebuild clean build \
     | tee ../../../build.log \
     | xcpretty &&
 cd ../../.. &&
-cat build.log | sh debug-time-function-bodies.sh
+cat build.log | sh debug-time-function-bodies.sh &&
 
 echo "Run building a tvOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,8 @@ time xcodebuild clean test \
     -scheme LayoutKit-iOS \
     -sdk iphonesimulator10.3 \
     -derivedDataPath $DERIVED_DATA \
-    -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' \
-    -destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=9.3' \
+    #-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' \
+    #-destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=9.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ echo "Derived data location: $DERIVED_DATA";
     #-destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=8.4' \
 
 set -o pipefail &&
-rm -rf $DERIVED_DATA &&
+instruments -s devices &&
 
 # Run test on iOS
 rm -rf $DERIVED_DATA &&

--- a/build.sh
+++ b/build.sh
@@ -66,7 +66,7 @@ time xcodebuild clean build \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \
     | tee ../build.log \
     | xcpretty &&
-cat build.log | sh debug-time-function-bodies.sh
+cat build.log | sh debug-time-function-bodies.sh &&
 
 # Test Cocopods, Carthage, Swift Package Management
 

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,6 @@ time xcodebuild clean test \
     -scheme LayoutKit-iOS \
     -sdk iphonesimulator10.3 \
     -derivedDataPath $DERIVED_DATA \
-    #-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' \
-    #-destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=9.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ echo "Derived data location: $DERIVED_DATA";
 set -o pipefail &&
 instruments -s devices &&
 
-# Run test on iOS
+echo "Run tests on iOS" &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean test \
     -project LayoutKit.xcodeproj \
@@ -27,7 +27,7 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-# Run test on MacOS
+echo "Run tests on MacOS" &&
 time xcodebuild clean test \
     -project LayoutKit.xcodeproj \
     -scheme LayoutKit-macOS \
@@ -38,7 +38,7 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-# Run test on tvOS
+echo "Run tests on tvOS" &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean test \
     -project LayoutKit.xcodeproj \
@@ -52,7 +52,7 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-# Build sample app
+echo "Test building sample app" &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean build \
     -project LayoutKit.xcodeproj \
@@ -70,7 +70,7 @@ cat build.log | sh debug-time-function-bodies.sh
 
 # Test Cocopods, Carthage, Swift Package Management
 
-# Build an iOS empty project with cocoapods
+echo "Test building an iOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/ios &&
 pod install &&
@@ -86,7 +86,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh
 
-# Build a macOS empty project with cocoapods
+echo "Test build a macOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/macos &&
 pod install &&
@@ -101,7 +101,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh
 
-# Build a tvOS empty project with cocoapods
+echo "Test building a tvOS empty project with cocoapods" &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/tvos &&
 pod install &&

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ echo "Derived data location: $DERIVED_DATA";
 
 set -o pipefail &&
 
-echo "Run tests on iOS" &&
+echo "Run tests on iOS..." &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean test \
     -project LayoutKit.xcodeproj \
@@ -21,7 +21,7 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run tests on MacOS" &&
+echo "Run tests on macOS..." &&
 time xcodebuild clean test \
     -project LayoutKit.xcodeproj \
     -scheme LayoutKit-macOS \
@@ -32,7 +32,7 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run tests on tvOS" &&
+echo "Run tests on tvOS..." &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean test \
     -project LayoutKit.xcodeproj \
@@ -46,15 +46,13 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run building sample app" &&
+echo "Run building sample app..." &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean build \
     -project LayoutKit.xcodeproj \
     -scheme LayoutKitSampleApp \
     -sdk iphonesimulator10.3 \
     -derivedDataPath $DERIVED_DATA \
-    -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' \
-    -destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=9.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \
@@ -64,7 +62,7 @@ cat build.log | sh debug-time-function-bodies.sh &&
 
 # Test Cocopods, Carthage, Swift Package Management
 
-echo "Run building an iOS empty project with cocoapods" &&
+echo "Run building an iOS empty project with cocoapods..." &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/ios &&
 pod install &&
@@ -80,7 +78,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run building a macOS empty project with cocoapods" &&
+echo "Run building a macOS empty project with cocoapods..." &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/macos &&
 pod install &&
@@ -95,7 +93,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run building a tvOS empty project with cocoapods" &&
+echo "Run building a tvOS empty project with cocoapods..." &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/tvos &&
 pod install &&


### PR DESCRIPTION
- [x] Remove iOS 9.3 simulators for tests to fix broken CI build
- [x] Investigate why the build still passes with an error
- [ ] Investigate how to enable iOS 9.3 simulator