### PR TITLE
Fix FeedItemLayoutKitView

### DIFF
--- a/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
+++ b/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
@@ -14,6 +14,14 @@ class FeedItemLayoutKitView: UIView, DataBinder {
 
     private var layout: FeedItemLayout? = nil
 
+    private var intrinsicContentSizeCalculated = false
+    
+    private lazy var heightConstraint: NSLayoutConstraint = {
+        let constraint = NSLayoutConstraint(item: self, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: self.bounds.height)
+        constraint.isActive = true
+        return constraint
+    }()
+    
     func setData(_ data: FeedItemData) {
         let posterProfile = ProfileCardLayout(
             name: data.posterName,
@@ -26,6 +34,10 @@ class FeedItemLayoutKitView: UIView, DataBinder {
         layout = FeedItemLayout(actionText: data.actionText, posterProfile: posterProfile, posterComment: data.posterComment, contentLayout: content, actorComment: data.actorComment)
         
         setNeedsLayout()
+        
+        if intrinsicContentSizeCalculated {
+            heightConstraint.constant = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude)).height
+        }
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {
@@ -33,6 +45,7 @@ class FeedItemLayoutKitView: UIView, DataBinder {
     }
 
     override var intrinsicContentSize: CGSize {
+        intrinsicContentSizeCalculated = true
         return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
     }
 

--- a/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
+++ b/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
@@ -42,8 +42,10 @@ class FeedItemLayoutKitView: UIView, DataBinder {
             contentLayout: content,
             actorComment: data.actorComment)
         
+        // Assure that `layoutSubviews` is called
         setNeedsLayout()
         
+        // Only calculate height for valid width
         if bounds.width > 0 {
             heightConstraint.constant = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude)).height
         }

--- a/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
+++ b/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
@@ -24,6 +24,8 @@ class FeedItemLayoutKitView: UIView, DataBinder {
 
         let content = ContentLayout(title: data.contentTitle, domain: data.contentDomain)
         layout = FeedItemLayout(actionText: data.actionText, posterProfile: posterProfile, posterComment: data.posterComment, contentLayout: content, actorComment: data.actorComment)
+        
+        setNeedsLayout()
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
+++ b/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
@@ -15,7 +15,13 @@ class FeedItemLayoutKitView: UIView, DataBinder {
     private var layout: FeedItemLayout? = nil
     
     private lazy var heightConstraint: NSLayoutConstraint = {
-        let constraint = NSLayoutConstraint(item: self, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: self.bounds.height)
+        let constraint = NSLayoutConstraint(
+            item: self, attribute: .height,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1,
+            constant: self.bounds.height)
         constraint.isActive = true
         return constraint
     }()
@@ -29,7 +35,12 @@ class FeedItemLayoutKitView: UIView, DataBinder {
             profileImageName: "50x50.png")
 
         let content = ContentLayout(title: data.contentTitle, domain: data.contentDomain)
-        layout = FeedItemLayout(actionText: data.actionText, posterProfile: posterProfile, posterComment: data.posterComment, contentLayout: content, actorComment: data.actorComment)
+        layout = FeedItemLayout(
+            actionText: data.actionText,
+            posterProfile: posterProfile,
+            posterComment: data.posterComment,
+            contentLayout: content,
+            actorComment: data.actorComment)
         
         setNeedsLayout()
         

--- a/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
+++ b/LayoutKitSampleApp/Benchmarks/FeedItemLayoutKitView.swift
@@ -13,8 +13,6 @@ import ExampleLayouts
 class FeedItemLayoutKitView: UIView, DataBinder {
 
     private var layout: FeedItemLayout? = nil
-
-    private var intrinsicContentSizeCalculated = false
     
     private lazy var heightConstraint: NSLayoutConstraint = {
         let constraint = NSLayoutConstraint(item: self, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: self.bounds.height)
@@ -35,7 +33,7 @@ class FeedItemLayoutKitView: UIView, DataBinder {
         
         setNeedsLayout()
         
-        if intrinsicContentSizeCalculated {
+        if bounds.width > 0 {
             heightConstraint.constant = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude)).height
         }
     }
@@ -45,7 +43,6 @@ class FeedItemLayoutKitView: UIView, DataBinder {
     }
 
     override var intrinsicContentSize: CGSize {
-        intrinsicContentSizeCalculated = true
         return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
     }
 


### PR DESCRIPTION
Implements fixes for `FeedItemLayoutKitView` issues described in #133.

- Fix for content not updating after cell reuse:
A simple `setNeedsLayout()`
- Fix for different cell heights being ignored:
A private height constraint.