### PR TITLE
Enabled iOS 9.3 simulators for unit test

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,8 @@ time xcodebuild clean test \
     -scheme LayoutKit-iOS \
     -sdk iphonesimulator10.3 \
     -derivedDataPath $DERIVED_DATA \
+    -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' \
+    -destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=9.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \
@@ -46,13 +48,15 @@ time xcodebuild clean test \
     | xcpretty &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run building sample app..." &&
+echo "Building sample app..." &&
 rm -rf $DERIVED_DATA &&
 time xcodebuild clean build \
     -project LayoutKit.xcodeproj \
     -scheme LayoutKitSampleApp \
     -sdk iphonesimulator10.3 \
     -derivedDataPath $DERIVED_DATA \
+    -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' \
+    -destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=9.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
     -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \
@@ -62,7 +66,7 @@ cat build.log | sh debug-time-function-bodies.sh &&
 
 # Test Cocopods, Carthage, Swift Package Management
 
-echo "Run building an iOS empty project with cocoapods..." &&
+echo "Building an iOS empty project with cocoapods..." &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/ios &&
 pod install &&
@@ -78,7 +82,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run building a macOS empty project with cocoapods..." &&
+echo "Building a macOS empty project with cocoapods..." &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/macos &&
 pod install &&
@@ -93,7 +97,7 @@ time xcodebuild clean build \
 cd ../../.. &&
 cat build.log | sh debug-time-function-bodies.sh &&
 
-echo "Run building a tvOS empty project with cocoapods..." &&
+echo "Building a tvOS empty project with cocoapods..." &&
 rm -rf $DERIVED_DATA &&
 cd Tests/cocoapods/tvos &&
 pod install &&


### PR DESCRIPTION
Travis-CI fixed the issues that iOS 9.3 simulators were not available. This PR adds those tests back.