### PR TITLE
Make custom view for UITableViewHeaderFooterView in it's contentView

### DIFF
--- a/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter+UITableView.swift
@@ -42,7 +42,7 @@ extension ReloadableViewLayoutAdapter: UITableViewDelegate {
             return nil
         }
         let view = dequeueHeaderFooterView(tableView: tableView)
-        layout.makeViews(in: view)
+        layout.makeViews(in: view.contentView)
         return view
     }
 


### PR DESCRIPTION
According to [Apple Docs](https://developer.apple.com/reference/uikit/uitableviewheaderfooterview) we should be creating our view in the UITableViewHeaderFooterView's contentView rather than itself. 

> If you have custom content to display, create the subviews for your content and add them to the view in the contentView property.