### PR TITLE
Incremental update is changed to use chunking

### DIFF
--- a/Sources/Views/ReloadableViewLayoutAdapter.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter.swift
@@ -15,6 +15,9 @@ import UIKit
  */
 open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDelegate {
 
+    static let incrementalUpdateChunkSize = 16
+    static let incrementalUpdateChunkingThreshold = 4 * incrementalUpdateChunkSize
+
     let reuseIdentifier = String(describing: ReloadableViewLayoutAdapter.self)
 
     /// The current layout arrangement.
@@ -118,6 +121,21 @@ open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDel
             BatchUpdateManager(delegate: self, operation: operation)
 
         operation.addExecutionBlock { [weak operation] in
+
+            func applyPartialArrangement(
+                header: LayoutArrangement?,
+                items: [LayoutArrangement],
+                footer: LayoutArrangement?,
+                pendingArrangement: [Section<[LayoutArrangement]>],
+                insertedIndexPaths: [IndexPath],
+                updateManager: ReloadableViewUpdateManager) {
+
+                let partialSection = Section(header: header, items: items, footer: footer)
+                var partialArrangement = pendingArrangement
+                partialArrangement.append(partialSection)
+                updateManager.apply(partialArrangement: partialArrangement, insertedIndexPaths: insertedIndexPaths)
+            }
+
             var pendingArrangement = [Section<[LayoutArrangement]>]()
             for (sectionIndex, sectionLayout) in layoutProvider().enumerated() {
                 if operation?.isCancelled ?? true {
@@ -127,6 +145,7 @@ open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDel
                 let header = sectionLayout.header.map(layoutFunc)
                 let footer = sectionLayout.footer.map(layoutFunc)
                 var items = [LayoutArrangement]()
+                var insertedIndexPaths = [IndexPath]()
 
                 for (itemIndex, itemLayout) in sectionLayout.items.enumerated() {
                     if operation?.isCancelled ?? true {
@@ -134,12 +153,18 @@ open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDel
                     }
 
                     items.append(layoutFunc(itemLayout))
+                    insertedIndexPaths.append(IndexPath(item: itemIndex, section: sectionIndex))
 
-                    let partialSection = Section(header: header, items: items, footer: footer)
-                    var partialArrangement = pendingArrangement
-                    partialArrangement.append(partialSection)
-                    let insertedIndexPath = IndexPath(item: itemIndex, section: sectionIndex)
-                    updateManager.apply(partialArrangement: partialArrangement, insertedIndexPath: insertedIndexPath)
+                    if (itemIndex <= ReloadableViewLayoutAdapter.incrementalUpdateChunkingThreshold
+                        || itemIndex % ReloadableViewLayoutAdapter.incrementalUpdateChunkSize == 0)
+                    {
+                        applyPartialArrangement(header: header, items: items, footer: footer, pendingArrangement: pendingArrangement, insertedIndexPaths: insertedIndexPaths, updateManager: updateManager)
+                        insertedIndexPaths.removeAll()
+                    }
+                }
+                
+                if insertedIndexPaths.isEmpty == false {
+                    applyPartialArrangement(header: header, items: items, footer: footer, pendingArrangement: pendingArrangement, insertedIndexPaths: insertedIndexPaths, updateManager: updateManager)
                 }
 
                 let pendingSection = Section(header: header, items: items, footer: footer)

--- a/Sources/Views/ReloadableViewUpdateManager.swift
+++ b/Sources/Views/ReloadableViewUpdateManager.swift
@@ -26,7 +26,7 @@ protocol ReloadableViewUpdateManager {
     weak var operation: Operation? { get }
 
     /// Applies a partial arrangement to the delegate's reloadable view and data source.
-    func apply(partialArrangement arrangement: [Section<[LayoutArrangement]>], insertedIndexPath: IndexPath)
+    func apply(partialArrangement arrangement: [Section<[LayoutArrangement]>], insertedIndexPaths: [IndexPath])
 
     /// Applies the final arrangement to the delegate's reloadable view and data source.
     func apply(finalArrangement arrangement: [Section<[LayoutArrangement]>], batchUpdates: BatchUpdates?, completion: (() -> Void)?)
@@ -65,9 +65,9 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
 
     private var pendingInsertedIndexPaths = [IndexPath]()
 
-    func apply(partialArrangement arrangement: [Section<[LayoutArrangement]>], insertedIndexPath: IndexPath) {
+    func apply(partialArrangement arrangement: [Section<[LayoutArrangement]>], insertedIndexPaths: [IndexPath]) {
         updateReloadableView(waitUntilFinished: false) { (reloadableView: ReloadableView) in
-            self.pendingInsertedIndexPaths.append(insertedIndexPath)
+            self.pendingInsertedIndexPaths += insertedIndexPaths
 
             // Don't modify the data while the view is moving.
             // Doing so causes weird artifacts (i.e. "bouncing" breaks).
@@ -114,14 +114,14 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
             reloadableView.perform(batchUpdates: batchUpdates)
         }
 
-        pendingInsertedIndexPaths.removeAll()
+        pendingInsertedIndexPaths.removeAll(keepingCapacity: true)
     }
 }
 
 /// Only updates the `ReloadableView` with the final arrangement.
 class BatchUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewUpdateManager {
 
-    func apply(partialArrangement arrangement: [Section<[LayoutArrangement]>], insertedIndexPath: IndexPath) {
+    func apply(partialArrangement arrangement: [Section<[LayoutArrangement]>], insertedIndexPaths: [IndexPath]) {
         // Nothing to do here. This update strategy ignores partial arrangements.
     }
 


### PR DESCRIPTION
This should reduce memory footprint on asynchronous loading of lots of items with `ReloadableViewLayoutAdapter` (#142).
The reason for that huge memory allocation is `items` is copied every time the `append` method is [called](https://github.com/linkedin/LayoutKit/blob/bdc0fdc9407d9e4cefc773401bf51e22779201bc/Sources/Views/ReloadableViewLayoutAdapter.swift#L136), means for each item in the section. The reason of that is `append` makes a copy in case the array passed somewhere else, and it is [passed](https://github.com/linkedin/LayoutKit/blob/bdc0fdc9407d9e4cefc773401bf51e22779201bc/Sources/Views/ReloadableViewLayoutAdapter.swift#L138) to the `Section` initializer for each iteration.
For some reason, ARC doesn't release memory used for array copies quickly, but does it slowly and only after all the items are loaded.
I changed the code to apply partial arrangements using chunks (16 is used as a chunk size), so the `items` should be copied less often.
I tested the issue #142 using Simulator with items number set to `10000`. Before my changes memory footprint in peak was more than *3 GB*, after changes it is less than *150 MB*.