### PR TITLE
Allow isSelectable overridden in TextViewLayout Configure

### DIFF
--- a/Sources/Layouts/TextViewLayout.swift
+++ b/Sources/Layouts/TextViewLayout.swift
@@ -130,8 +130,7 @@ open class TextViewLayout<TextView: UITextView>: BaseLayout<TextView>, Configura
     // MARK: - overriden methods
 
     open override func configure(view textView: TextView) {
-        /// `isSelectable` is default to false, but it allows overriding in `configure` block
-        /// By enabling it, it may have side effects
+        // `isSelectable` is default to false, but it allows overriding in `configure` block
         textView.isSelectable = false
 
         super.configure(view: textView)

--- a/Sources/Layouts/TextViewLayout.swift
+++ b/Sources/Layouts/TextViewLayout.swift
@@ -26,7 +26,7 @@ open class TextViewLayout<TextView: UITextView>: BaseLayout<TextView>, Configura
 
     /// Don't change `textContainerInset`, `lineFragmentPadding` and `usesFontLeading` in `configure` closure that's passed to init.
     /// By changing those, it will cause the Layout's size calculation to be incorrect. So they will be reset by using parameters from initializer.
-    /// `TextViewLayout` sets `usesFontLeading = false`, `isScrollEnabled = false`, `isSelectable` = false by the default. Don't override those values.
+    /// `TextViewLayout` sets `usesFontLeading = false`, `isScrollEnabled = false` by the default. Don't override those values.
     public init(text: Text,
                 font: UIFont? = nil,
                 lineFragmentPadding: CGFloat = 0,
@@ -130,9 +130,6 @@ open class TextViewLayout<TextView: UITextView>: BaseLayout<TextView>, Configura
     // MARK: - overriden methods
 
     open override func configure(view textView: TextView) {
-        // `isSelectable` is default to false, but it allows overriding in `configure` block
-        textView.isSelectable = false
-
         super.configure(view: textView)
         textView.textContainerInset = textContainerInset
         textView.textContainer.lineFragmentPadding = lineFragmentPadding

--- a/Sources/Layouts/TextViewLayout.swift
+++ b/Sources/Layouts/TextViewLayout.swift
@@ -130,6 +130,10 @@ open class TextViewLayout<TextView: UITextView>: BaseLayout<TextView>, Configura
     // MARK: - overriden methods
 
     open override func configure(view textView: TextView) {
+        /// `isSelectable` is default to false, but it allows overriding in `configure` block
+        /// By enabling it, it may have side effects
+        textView.isSelectable = false
+
         super.configure(view: textView)
         textView.textContainerInset = textContainerInset
         textView.textContainer.lineFragmentPadding = lineFragmentPadding
@@ -139,7 +143,6 @@ open class TextViewLayout<TextView: UITextView>: BaseLayout<TextView>, Configura
         #if !os(tvOS)
             textView.isEditable = false
         #endif
-        textView.isSelectable = false
         textView.font = font
 
         switch text {


### PR DESCRIPTION
Originally, we don't allow `isSelectable` overridden in `TextViewLayout` because there was a view issue. After re-tested it on iOS 10/11, it looks OK. As a result, `isSelectable` moved to before `configure`, so that it can be overridden in configure block.