### PR TITLE
Fixing async issue on completion callback for perform batch updates

### DIFF
--- a/Sources/Views/ReloadableView.swift
+++ b/Sources/Views/ReloadableView.swift
@@ -89,9 +89,9 @@ extension UICollectionView: ReloadableView {
             for move in batchUpdates.moveSections {
                 self.moveSection(move.from, toSection: move.to)
             }
-        }) { _ in
+        }, completion: { _ in
             completion?()
-        }
+        })
     }
 }
 

--- a/Sources/Views/ReloadableView.swift
+++ b/Sources/Views/ReloadableView.swift
@@ -41,7 +41,7 @@ public protocol ReloadableView: class {
      The reloadable view must follow the same semantics for handling the index paths
      of concurrent inserts/updates/deletes as UICollectionView documents in `performBatchUpdates`.
      */
-    func perform(batchUpdates: BatchUpdates)
+    func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?)
 }
 
 // MARK: - UICollectionView
@@ -62,7 +62,7 @@ extension UICollectionView: ReloadableView {
         register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionFooter, withReuseIdentifier: reuseIdentifier)
     }
 
-    open func perform(batchUpdates: BatchUpdates) {
+    open func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?) {
         performBatchUpdates({
             if batchUpdates.insertItems.count > 0 {
                 self.insertItems(at: batchUpdates.insertItems)
@@ -89,7 +89,9 @@ extension UICollectionView: ReloadableView {
             for move in batchUpdates.moveSections {
                 self.moveSection(move.from, toSection: move.to)
             }
-        }, completion: nil)
+        }) { _ in
+            completion?()
+        }
     }
 }
 
@@ -107,7 +109,7 @@ extension UITableView: ReloadableView {
         register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: reuseIdentifier)
     }
 
-    open func perform(batchUpdates: BatchUpdates) {
+    open func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?) {
         beginUpdates()
 
         // Update items.
@@ -139,5 +141,7 @@ extension UITableView: ReloadableView {
         }
 
         endUpdates()
+
+        completion?()
     }
 }

--- a/Sources/Views/ReloadableViewLayoutAdapter.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter.swift
@@ -92,13 +92,13 @@ open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDel
             return sectionLayout.map(layoutFunc)
         }
         if let batchUpdates = batchUpdates {
-            reloadableView?.perform(batchUpdates: batchUpdates)
+            reloadableView?.perform(batchUpdates: batchUpdates, completion: completion)
         } else {
             reloadableView?.reloadDataSynchronously()
+            completion?()
         }
         let end = CFAbsoluteTimeGetCurrent()
         logger?("user: \((end-start).ms)")
-        completion?()
     }
 
     private func reloadAsynchronously<T: Collection, U: Collection>(

--- a/Sources/Views/ReloadableViewUpdateManager.swift
+++ b/Sources/Views/ReloadableViewUpdateManager.swift
@@ -111,7 +111,7 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
                     batchUpdates.insertItems.append(pendingInsertedIndexPath)
                 }
             }
-            reloadableView.perform(batchUpdates: batchUpdates)
+            reloadableView.perform(batchUpdates: batchUpdates, completion: nil)
         }
 
         pendingInsertedIndexPaths.removeAll()
@@ -137,12 +137,11 @@ class BatchUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewUpdateM
             // Perform the update.
             delegate.currentArrangement = arrangement
             if canBatchUpdate, let batchUpdates = batchUpdates {
-                reloadableView.perform(batchUpdates: batchUpdates)
+                reloadableView.perform(batchUpdates: batchUpdates, completion: completion)
             } else {
                 reloadableView.reloadDataSynchronously()
+                completion?()
             }
-            
-            completion?()
         }
     }
 }

--- a/Sources/Views/ReloadableViewUpdateManager.swift
+++ b/Sources/Views/ReloadableViewUpdateManager.swift
@@ -100,6 +100,7 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
         if oldArrangement.isEmpty {
             // Can't do incremental updates on an empty reloadable view.
             reloadableView.reloadDataSynchronously()
+            pendingInsertedIndexPaths.removeAll()
         } else {
             // Compute the actual inserted index paths.
             // If indexes are inserted into a section that doesn't exist, then we insert the section instead.
@@ -111,10 +112,10 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
                     batchUpdates.insertItems.append(pendingInsertedIndexPath)
                 }
             }
-            reloadableView.perform(batchUpdates: batchUpdates, completion: nil)
+            reloadableView.perform(batchUpdates: batchUpdates, completion: {
+                self.pendingInsertedIndexPaths.removeAll()
+            })
         }
-
-        pendingInsertedIndexPaths.removeAll()
     }
 }
 


### PR DESCRIPTION
Currently the completion callback when performing a reload with batch updates is being called prematurely because performing batch updates happens asynchronously on the animation thread. We should use the completion block provided by performBatchUpdates(:) instead