### PR TITLE
Fixing async issue on completion callback for perform batch updates

### DIFF
--- a/LayoutKitTests/ReloadableViewLayoutAdapterTestCase.swift
+++ b/LayoutKitTests/ReloadableViewLayoutAdapterTestCase.swift
@@ -70,7 +70,7 @@ class ReloadableViewLayoutAdapterTestCase: XCTestCase {
 
         // Test batch update to layout two.
         do {
-            var completed = false
+            let completionExpectation = expectation(description: "completion")
             let batchUpdates = batchUpdatesForLayoutTwo()
             view.layoutAdapter.reload(
                 width: view.bounds.width,
@@ -78,10 +78,10 @@ class ReloadableViewLayoutAdapterTestCase: XCTestCase {
                 batchUpdates: batchUpdates,
                 layoutProvider: layoutProviderTwo,
                 completion: {
-                    completed = true
+                    completionExpectation.fulfill()
                 }
             )
-            XCTAssertTrue(completed)
+            waitForExpectations(timeout: 10, handler: nil)
 
             // Need to trigger a layout on UICollectionViews so we can test the results.
             (view as? UICollectionView)?.layoutIfNeeded()
@@ -100,7 +100,7 @@ class ReloadableViewLayoutAdapterTestCase: XCTestCase {
 
         // Test batch update to layout three.
         do {
-            var completed = false
+            let completionExpectation = expectation(description: "completion")
             let batchUpdates = batchUpdatesForLayoutThree()
             view.layoutAdapter.reload(
                 width: view.bounds.width,
@@ -108,10 +108,10 @@ class ReloadableViewLayoutAdapterTestCase: XCTestCase {
                 batchUpdates: batchUpdates,
                 layoutProvider: layoutProviderThree,
                 completion: {
-                    completed = true
+                    completionExpectation.fulfill()
                 }
             )
-            XCTAssertTrue(completed)
+            waitForExpectations(timeout: 10, handler: nil)
 
             // Need to trigger a layout on UICollectionViews so we can test the results.
             (view as? UICollectionView)?.layoutIfNeeded()

--- a/LayoutKitTests/ReloadableViewTests.swift
+++ b/LayoutKitTests/ReloadableViewTests.swift
@@ -41,7 +41,7 @@ class ReloadableViewTests: XCTestCase {
 
         // upcast to UICollectionView to make sure that overloading works correctly
         let collectionView: UICollectionView = registerViewsCollectionView
-        collectionView.perform(batchUpdates: BatchUpdates())
+        collectionView.perform(batchUpdates: BatchUpdates(), completion: nil)
 
         waitForExpectations(timeout: 10.0, handler: nil)
     }
@@ -77,7 +77,7 @@ class ReloadableViewTests: XCTestCase {
 
         // upcast to UITableView to make sure that overloading works correctly
         let tableView: UITableView = registerViewsTableView
-        tableView.perform(batchUpdates: BatchUpdates())
+        tableView.perform(batchUpdates: BatchUpdates(), completion: nil)
 
         waitForExpectations(timeout: 10.0, handler: nil)
     }
@@ -99,7 +99,7 @@ class RegisterViewsCollectionView: UICollectionView {
 
     var performExpectation: XCTestExpectation?
 
-    override func perform(batchUpdates: BatchUpdates) {
+    override func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?) {
         performExpectation?.fulfill()
     }
 }
@@ -120,7 +120,7 @@ class RegisterViewsTableView: UITableView {
 
     var performExpectation: XCTestExpectation?
 
-    override func perform(batchUpdates: BatchUpdates) {
+    override func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?) {
         performExpectation?.fulfill()
     }
 }

--- a/Sources/Views/ReloadableView.swift
+++ b/Sources/Views/ReloadableView.swift
@@ -41,7 +41,7 @@ public protocol ReloadableView: class {
      The reloadable view must follow the same semantics for handling the index paths
      of concurrent inserts/updates/deletes as UICollectionView documents in `performBatchUpdates`.
      */
-    func perform(batchUpdates: BatchUpdates)
+    func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?)
 }
 
 // MARK: - UICollectionView
@@ -62,7 +62,7 @@ extension UICollectionView: ReloadableView {
         register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionFooter, withReuseIdentifier: reuseIdentifier)
     }
 
-    open func perform(batchUpdates: BatchUpdates) {
+    open func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?) {
         performBatchUpdates({
             if batchUpdates.insertItems.count > 0 {
                 self.insertItems(at: batchUpdates.insertItems)
@@ -89,7 +89,9 @@ extension UICollectionView: ReloadableView {
             for move in batchUpdates.moveSections {
                 self.moveSection(move.from, toSection: move.to)
             }
-        }, completion: nil)
+        }, completion: { _ in
+            completion?()
+        })
     }
 }
 
@@ -107,7 +109,7 @@ extension UITableView: ReloadableView {
         register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: reuseIdentifier)
     }
 
-    open func perform(batchUpdates: BatchUpdates) {
+    open func perform(batchUpdates: BatchUpdates, completion: (() -> Void)?) {
         beginUpdates()
 
         // Update items.
@@ -139,5 +141,7 @@ extension UITableView: ReloadableView {
         }
 
         endUpdates()
+
+        completion?()
     }
 }

--- a/Sources/Views/ReloadableViewLayoutAdapter.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter.swift
@@ -92,13 +92,13 @@ open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDel
             return sectionLayout.map(layoutFunc)
         }
         if let batchUpdates = batchUpdates {
-            reloadableView?.perform(batchUpdates: batchUpdates)
+            reloadableView?.perform(batchUpdates: batchUpdates, completion: completion)
         } else {
             reloadableView?.reloadDataSynchronously()
+            completion?()
         }
         let end = CFAbsoluteTimeGetCurrent()
         logger?("user: \((end-start).ms)")
-        completion?()
     }
 
     private func reloadAsynchronously<T: Collection, U: Collection>(

--- a/Sources/Views/ReloadableViewLayoutAdapter.swift
+++ b/Sources/Views/ReloadableViewLayoutAdapter.swift
@@ -91,14 +91,19 @@ open class ReloadableViewLayoutAdapter: NSObject, ReloadableViewUpdateManagerDel
         currentArrangement = layoutProvider().map { sectionLayout in
             return sectionLayout.map(layoutFunc)
         }
-        if let batchUpdates = batchUpdates {
-            reloadableView?.perform(batchUpdates: batchUpdates, completion: completion)
-        } else {
-            reloadableView?.reloadDataSynchronously()
+
+        let completionAndLogEnd = {
+            let end = CFAbsoluteTimeGetCurrent()
+            self.logger?("user: \((end-start).ms)")
             completion?()
         }
-        let end = CFAbsoluteTimeGetCurrent()
-        logger?("user: \((end-start).ms)")
+
+        if let batchUpdates = batchUpdates {
+            reloadableView?.perform(batchUpdates: batchUpdates, completion: completionAndLogEnd)
+        } else {
+            reloadableView?.reloadDataSynchronously()
+            completionAndLogEnd()
+        }
     }
 
     private func reloadAsynchronously<T: Collection, U: Collection>(

--- a/Sources/Views/ReloadableViewUpdateManager.swift
+++ b/Sources/Views/ReloadableViewUpdateManager.swift
@@ -100,6 +100,7 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
         if oldArrangement.isEmpty {
             // Can't do incremental updates on an empty reloadable view.
             reloadableView.reloadDataSynchronously()
+            pendingInsertedIndexPaths.removeAll()
         } else {
             // Compute the actual inserted index paths.
             // If indexes are inserted into a section that doesn't exist, then we insert the section instead.
@@ -111,10 +112,10 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
                     batchUpdates.insertItems.append(pendingInsertedIndexPath)
                 }
             }
-            reloadableView.perform(batchUpdates: batchUpdates)
+            reloadableView.perform(batchUpdates: batchUpdates, completion: {
+                self.pendingInsertedIndexPaths.removeAll()
+            })
         }
-
-        pendingInsertedIndexPaths.removeAll()
     }
 }
 
@@ -137,12 +138,11 @@ class BatchUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewUpdateM
             // Perform the update.
             delegate.currentArrangement = arrangement
             if canBatchUpdate, let batchUpdates = batchUpdates {
-                reloadableView.perform(batchUpdates: batchUpdates)
+                reloadableView.perform(batchUpdates: batchUpdates, completion: completion)
             } else {
                 reloadableView.reloadDataSynchronously()
+                completion?()
             }
-            
-            completion?()
         }
     }
 }

--- a/Sources/Views/ReloadableViewUpdateManager.swift
+++ b/Sources/Views/ReloadableViewUpdateManager.swift
@@ -100,7 +100,6 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
         if oldArrangement.isEmpty {
             // Can't do incremental updates on an empty reloadable view.
             reloadableView.reloadDataSynchronously()
-            pendingInsertedIndexPaths.removeAll()
         } else {
             // Compute the actual inserted index paths.
             // If indexes are inserted into a section that doesn't exist, then we insert the section instead.
@@ -112,10 +111,10 @@ class IncrementalUpdateManager: BaseReloadableViewUpdateManager, ReloadableViewU
                     batchUpdates.insertItems.append(pendingInsertedIndexPath)
                 }
             }
-            reloadableView.perform(batchUpdates: batchUpdates, completion: {
-                self.pendingInsertedIndexPaths.removeAll()
-            })
+            reloadableView.perform(batchUpdates: batchUpdates, completion: nil)
         }
+
+        pendingInsertedIndexPaths.removeAll()
     }
 }
 


### PR DESCRIPTION
Currently the completion callback when performing a reload with batch updates is being called prematurely because performing batch updates happens asynchronously on the animation thread. We should use the completion block provided by performBatchUpdates(:) instead