### PR TITLE
fix LabelLayout async init used UILabel().

### DIFF
--- a/LayoutKitTests/LabelLayoutTests.swift
+++ b/LayoutKitTests/LabelLayoutTests.swift
@@ -60,6 +60,17 @@ class LabelLayoutTests: XCTestCase {
 
         XCTAssertEqual(arrangement.makeViews().frame.size, label.intrinsicContentSize)
     }
+    
+    func testAsyncAttributedLabel() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let attributedText = NSAttributedString(string: "Async", attributes: [NSAttributedStringKey.font: UIFont.helvetica(size: 42)])
+            let arrangement = LabelLayout(attributedText: attributedText).arrangement()
+            DispatchQueue.main.async {
+                let label = UILabel(attributedText: attributedText, font: UIFont.helvetica(size: 42))
+                XCTAssertEqual(arrangement.makeViews().frame.size, label.intrinsicContentSize)
+            }
+        }
+    }
 
     func testTwoLineLabel() {
         let text = "Nick Snyder"

--- a/Sources/Layouts/LabelLayout.swift
+++ b/Sources/Layouts/LabelLayout.swift
@@ -112,7 +112,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
 
 public class LabelLayoutDefaults {
     public static let defaultNumberOfLines = 0
-    public static let defaultFont = UILabel().font ?? UIFont.systemFont(ofSize: 17)
+    public static let defaultFont = UIFont.systemFont(ofSize: 17)
     public static let defaultAlignment = Alignment.topLeading
     public static let defaultFlexibility = Flexibility.flexible
 }


### PR DESCRIPTION
If we initialize the LabelLayout asynchronously with an NSAttributedString, most of the time we don't have to set the font, but the default access to UILabel(). Font, this is not safe.I don't quite understand why this is designed in this way.