### PR TITLE
Remove "docs: null%" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![GitHub release](https://img.shields.io/github/release/linkedin/layoutkit.svg?maxAge=3600)](https://github.com/linkedin/LayoutKit/releases)
 [![Build Status](https://travis-ci.org/linkedin/LayoutKit.svg?branch=master)](https://travis-ci.org/linkedin/LayoutKit)
 [![codecov](https://codecov.io/gh/linkedin/LayoutKit/branch/master/graph/badge.svg)](https://codecov.io/gh/linkedin/LayoutKit)
-[![CocoaPods](https://img.shields.io/cocoapods/metrics/doc-percent/LayoutKit.svg?maxAge=3600)](http://cocoadocs.org/docsets/LayoutKit)
 
 LayoutKit is a fast view layout library for iOS, macOS, and tvOS.
 


### PR DESCRIPTION
<img width="67" alt="screen shot 2017-12-08 at 10 06 46 am" src="https://user-images.githubusercontent.com/238331/33778902-982ebd02-dbff-11e7-8c7d-4213fb0e908d.png">


This badge appears to broken for others as well:
<img width="623" alt="screen shot 2017-12-08 at 10 08 16 am" src="https://user-images.githubusercontent.com/238331/33778955-c5bbdb9c-dbff-11e7-969c-3fc6c51f8b3a.png">
