### PR TITLE
Add Cocoapods static_framework support

### DIFF
--- a/LayoutKit.podspec
+++ b/LayoutKit.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |spec|
   spec.source            = { :git => 'https://github.com/linkedin/LayoutKit.git', :tag => spec.version }
   spec.source_files      = 'Sources/**/*.swift'
   spec.documentation_url = 'http://layoutkit.org'
+  spec.static_framework  = true
 
   spec.ios.deployment_target = '8.0'
   spec.ios.frameworks        = 'Foundation', 'CoreGraphics', 'UIKit'

--- a/Sources/ViewRecycler.swift
+++ b/Sources/ViewRecycler.swift
@@ -6,7 +6,7 @@
 // software distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
-import ObjectiveC
+import Foundation
 
 /**
  Provides APIs to recycle views by id.


### PR DESCRIPTION
I see Cocoapods RC (1.4.0.rc.1) supports swift static frameworks. Added that to avoid creating a dynamic library.
The latest Cocoapods RC can be installed using this command ```sudo gem install cocoapods --pre```
