### PR TITLE
SND-4566: Letter "g" cutoff in search hits

### DIFF
--- a/Sources/Layouts/LabelLayout.swift
+++ b/Sources/Layouts/LabelLayout.swift
@@ -16,9 +16,11 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
     open let text: Text
     open let font: UIFont
     open let numberOfLines: Int
+    open let lineHeight: CGFloat
 
     public init(text: Text,
                 font: UIFont = LabelLayoutDefaults.defaultFont,
+                lineHeight: CGFloat? = nil,
                 numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
                 alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
                 flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
@@ -28,6 +30,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
         self.text = text
         self.numberOfLines = numberOfLines
         self.font = font
+        self.lineHeight = lineHeight ?? font.lineHeight
         super.init(alignment: alignment, flexibility: flexibility, viewReuseId: viewReuseId, config: config)
     }
 
@@ -35,6 +38,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
 
     public convenience init(text: String,
                             font: UIFont = LabelLayoutDefaults.defaultFont,
+                            lineHeight: CGFloat? = nil,
                             numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
                             alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
                             flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
@@ -43,6 +47,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
 
         self.init(text: .unattributed(text),
                   font: font,
+                  lineHeight: lineHeight,
                   numberOfLines: numberOfLines,
                   alignment: alignment,
                   flexibility: flexibility,
@@ -52,6 +57,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
 
     public convenience init(attributedText: NSAttributedString,
                             font: UIFont = LabelLayoutDefaults.defaultFont,
+                            lineHeight: CGFloat? = nil,
                             numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
                             alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
                             flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
@@ -60,6 +66,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
 
         self.init(text: .attributed(attributedText),
                   font: font,
+                  lineHeight: lineHeight,
                   numberOfLines: numberOfLines,
                   alignment: alignment,
                   flexibility: flexibility,
@@ -77,7 +84,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
     private func textSize(within maxSize: CGSize) -> CGSize {
         var size = text.textSize(within: maxSize, font: font)
         if numberOfLines > 0 {
-            let maxHeight = (CGFloat(numberOfLines) * font.lineHeight).roundedUpToFractionalPoint
+            let maxHeight = (CGFloat(numberOfLines) * lineHeight).roundedUpToFractionalPoint
             if size.height > maxHeight {
                 size = CGSize(width: maxSize.width, height: maxHeight)
             }


### PR DESCRIPTION
SND-4566: Letter "g" cutoff in search hits

**Issue:**
\- While applying `ARTTextStyle` to Label, it internally add the attributes 
  to label such as `NSParagraphStyleAttributeName`. And uses `ARTTextStyle.lineHeight` 
  for `minimumLineHeight` and `maximumLineHeight` properties of this attribute.
\- If `ARTTextStyle.lineHeight` is larger than `font.lineHeight`, label's bottom gets truncated.

**Cause:**
\- While calculating height, If `numberOfLines` is greater than 0 then, `font.lineHeight` 
  is being used for height calculation. But actually in UI, `ARTTextStyle.lineHeight` is being rendered.
 
**Fix:**
\- So to fix this issue, added line height to LabelLayout. 
\- Added `lineHeight` parameter to LabelLayout's `init(...)` method and used it for height calculation
\- Please see the discussion in RB- https://rb.corp.linkedin.com/r/1214302/#comment3598733.