### PR TITLE
Fixed Swift ObjC Wrapper of layout

### DIFF
--- a/Sources/ObjCSupport/LOKLayout.swift
+++ b/Sources/ObjCSupport/LOKLayout.swift
@@ -20,6 +20,16 @@ import CoreGraphics
 
 extension LOKLayout {
     var unwrapped: Layout {
+        /*
+         Need to check to see if `self` is one of the LayoutKit provided layouts.
+         If so, we want to cast it as `LOKBaseLayout` and return the wrapped layout
+         object directly.
+
+         If `self` is not one of the LayoutKit provided layouts, we want to wrap it
+         so that the methods of the class are called. We do this to make sure that if
+         someone were to subclass one of the LayoutKit provided layouts, we would want
+         to call their overriden methods instead of just the underlying layout object directly.
+         */
         let allLayoutClasses = [
             LOKButtonLayout.self,
             LOKInsetLayout.self,
@@ -30,10 +40,8 @@ extension LOKLayout {
             LOKTextViewLayout.self
         ]
         if let object = self as? NSObject {
-            // Need to check to see if `self` is one of the LayoutKit provided layouts.
-            // If so, we want to cast it as `LOKBaseLayout` and return the wrapped layout
-            // object directly.
             if allLayoutClasses.contains(where: { object.isMember(of: $0) }) {
+                // Executes if `self` is one of the LayoutKit provided classes; not if it's a subclass
                 guard let layout = (self as? LOKBaseLayout)?.layout else {
                     assertionFailure("LayoutKit provided layout does not inherit from LOKBaseLayout")
                     return ReverseWrappedLayout(layout: self)
@@ -41,10 +49,6 @@ extension LOKLayout {
                 return layout
             }
         }
-        // If `self` is not one of the LayoutKit provided layouts, we want to wrap it
-        // so that the methods of the class are called. We do this to make sure that if
-        // someone were to subclass one of the LayoutKit provided layouts, we would want
-        // to call their overriden methods instead of just the underlying layout object directly.
         return (self as? WrappedLayout)?.layout ?? ReverseWrappedLayout(layout: self)
     }
 }

--- a/Sources/ObjCSupport/LOKLayout.swift
+++ b/Sources/ObjCSupport/LOKLayout.swift
@@ -20,6 +20,24 @@ import CoreGraphics
 
 extension LOKLayout {
     var unwrapped: Layout {
-        return (self as? WrappedLayout)?.layout ?? (self as? LOKBaseLayout)?.layout ?? ReverseWrappedLayout(layout: self)
+        let allLayoutClasses = [
+            LOKButtonLayout.self,
+            LOKInsetLayout.self,
+            LOKLabelLayout.self,
+            LOKOverlayLayout.self,
+            LOKSizeLayout.self,
+            LOKStackLayout.self,
+            LOKTextViewLayout.self
+        ]
+        if let object = self as? NSObject {
+            if allLayoutClasses.contains(where: { object.isMember(of: $0) }) {
+                guard let layout = (self as? LOKBaseLayout)?.layout else {
+                    assertionFailure("LayoutKit provided layout does not inherit from LOKBaseLayout")
+                    return ReverseWrappedLayout(layout: self)
+                }
+                return layout
+            }
+        }
+        return (self as? WrappedLayout)?.layout ?? ReverseWrappedLayout(layout: self)
     }
 }

--- a/Sources/ObjCSupport/LOKLayout.swift
+++ b/Sources/ObjCSupport/LOKLayout.swift
@@ -30,6 +30,9 @@ extension LOKLayout {
             LOKTextViewLayout.self
         ]
         if let object = self as? NSObject {
+            // Need to check to see if `self` is one of the LayoutKit provided layouts.
+            // If so, we want to cast it as `LOKBaseLayout` and return the wrapped layout
+            // object directly.
             if allLayoutClasses.contains(where: { object.isMember(of: $0) }) {
                 guard let layout = (self as? LOKBaseLayout)?.layout else {
                     assertionFailure("LayoutKit provided layout does not inherit from LOKBaseLayout")
@@ -38,6 +41,10 @@ extension LOKLayout {
                 return layout
             }
         }
+        // If `self` is not one of the LayoutKit provided layouts, we want to wrap it
+        // so that the methods of the class are called. We do this to make sure that if
+        // someone were to subclass one of the LayoutKit provided layouts, we would want
+        // to call their overriden methods instead of just the underlying layout object directly.
         return (self as? WrappedLayout)?.layout ?? ReverseWrappedLayout(layout: self)
     }
 }


### PR DESCRIPTION
There could be an issue if you inherit from one of the provided layouts from LayoutKit. This fix makes it so that if you do that, it will call the correct overridden methods.