### PR TITLE
Making property and function as open and exposing "items" property in LOKLayoutArrangementSection

### DIFF
--- a/Sources/ObjCSupport/LOKBaseLayout.swift
+++ b/Sources/ObjCSupport/LOKBaseLayout.swift
@@ -23,7 +23,7 @@ open class LOKBaseLayout: NSObject, LOKLayout {
         return LOKLayoutArrangement(layoutArrangement: layout.arrangement(within: rect, measurement: measurement.measurement))
     }
 
-    public var needsView: Bool {
+    open var needsView: Bool {
         return layout.needsView
     }
 
@@ -31,7 +31,7 @@ open class LOKBaseLayout: NSObject, LOKLayout {
         return layout.makeView()
     }
 
-    public func configure(baseTypeView: View) {
+    open func configure(baseTypeView: View) {
         layout.configure(baseTypeView: baseTypeView)
     }
 

--- a/Sources/ObjCSupport/LOKFlexibility.swift
+++ b/Sources/ObjCSupport/LOKFlexibility.swift
@@ -22,6 +22,7 @@ import Foundation
     @objc public static let high = LOKFlexibility(flexibility: .high)
     @objc public static let low = LOKFlexibility(flexibility: .low)
 
+    @objc public static let horizontallyHighlyFlexible = LOKFlexibility(flexibility: Flexibility(horizontal: Flexibility.highFlex, vertical: Flexibility.inflexibleFlex))
     @objc public static let horizontallyFlexible = LOKFlexibility(flexibility: Flexibility(horizontal: Flexibility.defaultFlex, vertical: Flexibility.inflexibleFlex))
     @objc public static let verticallyFlexible = LOKFlexibility(flexibility: Flexibility(horizontal: Flexibility.inflexibleFlex, vertical: Flexibility.defaultFlex))
 }

--- a/Sources/ObjCSupport/LOKLayoutArrangementSection.swift
+++ b/Sources/ObjCSupport/LOKLayoutArrangementSection.swift
@@ -10,7 +10,13 @@ import Foundation
 
 @objc open class LOKLayoutArrangementSection: NSObject {
     let unwrapped: Section<[LayoutArrangement]>
+    @objc public let header: LOKLayoutArrangement?
+    @objc public let items: [LOKLayoutArrangement]
+    @objc public let footer: LOKLayoutArrangement?
     @objc public init(header: LOKLayoutArrangement?, items: [LOKLayoutArrangement], footer: LOKLayoutArrangement?) {
+        self.header = header
+        self.items = items
+        self.footer = footer
         unwrapped = Section(header: header?.layoutArrangement, items: items.map { $0.layoutArrangement }, footer: footer?.layoutArrangement)
     }
 }


### PR DESCRIPTION
Making property and function as open and exposing "items" property in LOKLayoutArrangementSection

1. Added open access specifier for following cases so we can override it in other modules:
   - Making `LOKBaseLayout.needsView` property as open
   - Making [LOKBaseLayout configure] function open
2. Creating a public property "items" in LOKLayoutArrangementSection, so we can access "items" from the object of LOKLayoutArrangementSection wherever needed in code
3. Added `horizontallyHighlyFlexible` static constant in LOKFlexibility