### PR TITLE
Passing default nil value for maxWidth and maxHeight while creating SizeLayout from LOKSizeLayout.

### DIFF
--- a/Sources/ObjCSupport/LOKSizeLayout.swift
+++ b/Sources/ObjCSupport/LOKSizeLayout.swift
@@ -21,9 +21,9 @@ import CoreGraphics
                       configure: ((View) -> Void)? = nil) {
         let layout = SizeLayout(
             minWidth: minWidth,
-            maxWidth: maxWidth,
+            maxWidth: maxWidth.isFinite ? maxWidth : nil,
             minHeight: minHeight,
-            maxHeight: maxHeight,
+            maxHeight: maxHeight.isFinite ? maxHeight : nil,
             alignment: alignment?.alignment,
             flexibility: flexibility?.flexibility,
             viewReuseId: viewReuseId,


### PR DESCRIPTION
Passing default nil value for `maxWidth` and `maxHeight` while creating `SizeLayout` from `LOKSizeLayout`.

- `LOKSizeLayoutBuilder` sets `INFINITY` as default value for `maxWidth` and `maxHeight`.
- In `LOKSizeLayout`, these values are used to create `SizeLayout` and `SizeLayout` decides
  its alignment using these values if `alignment` property is not set by caller.
- In above case, vertical and horizontal values of alignment will be set to `.center`.
- But for `SizeLayout`, default value for `maxWidth` and `maxHeight` is nil so vertical and
  horizontal values of alignment will be set to .fill.
- So to keep same behavior in `LOKSizeLayout`, we have to pass nil value for maxWidth and maxHeight when these values are not finite.