### PR TITLE
Making LOKLayout configureView method non-optional

### DIFF
--- a/LayoutKitObjCSampleApp/RotationLayout.m
+++ b/LayoutKitObjCSampleApp/RotationLayout.m
@@ -50,6 +50,10 @@
     return [[RotationView alloc] init];
 }
 
+- (void)configureView:(UIView *)view {
+    
+}
+
 - (nonnull LOKLayoutMeasurement *)measurementWithin:(CGSize)maxSize {
     LOKLayoutMeasurement *sublayoutMeasurement = [self.sublayout measurementWithin:maxSize];
     CGSize rotatedSize = CGSizeMake(sublayoutMeasurement.size.height, sublayoutMeasurement.size.width);

--- a/Sources/ObjCSupport/Internal/ReverseWrappedLayout.swift
+++ b/Sources/ObjCSupport/Internal/ReverseWrappedLayout.swift
@@ -27,7 +27,7 @@ class ReverseWrappedLayout: Layout {
     }
 
     func configure(baseTypeView: View) {
-        layout.configureView?(baseTypeView)
+        layout.configureView(baseTypeView)
     }
 
     var flexibility: Flexibility {

--- a/Sources/ObjCSupport/Internal/WrappedLayout.swift
+++ b/Sources/ObjCSupport/Internal/WrappedLayout.swift
@@ -28,8 +28,8 @@ class WrappedLayout: LOKLayout {
         return layout.makeView()
     }
 
-    func configure(baseTypeView: View) {
-        layout.configure(baseTypeView: baseTypeView)
+    func configureView(_ view: View) {
+        layout.configure(baseTypeView: view)
     }
 
     var flexibility: LOKFlexibility {

--- a/Sources/ObjCSupport/LOKBaseLayout.swift
+++ b/Sources/ObjCSupport/LOKBaseLayout.swift
@@ -41,8 +41,8 @@ open class LOKBaseLayout: NSObject, LOKLayout {
         return layout.makeView()
     }
 
-    open func configure(baseTypeView: View) {
-        layout.configure(baseTypeView: baseTypeView)
+    open func configureView(_ view: View) {
+        layout.configure(baseTypeView: view)
     }
 
     public var flexibility: LOKFlexibility {

--- a/Sources/ObjCSupport/LOKLayout.swift
+++ b/Sources/ObjCSupport/LOKLayout.swift
@@ -13,7 +13,7 @@ import CoreGraphics
     @objc func arrangement(within rect: CGRect, measurement: LOKLayoutMeasurement) -> LOKLayoutArrangement
     @objc var needsView: Bool { get }
     @objc func makeView() -> View
-    @objc optional func configureView(_ view: View)
+    @objc func configureView(_ view: View)
     @objc var flexibility: LOKFlexibility { get }
     @objc var viewReuseId: String? { get }
 }


### PR DESCRIPTION
There have been several issues where the configure method was not implemented or implemented with slightly wrong signature, so we’re making it non-optional.