### PR TITLE
Reset reused views' transform and layer anchor point

### DIFF
--- a/LayoutKitTests/ViewRecyclerTests.swift
+++ b/LayoutKitTests/ViewRecyclerTests.swift
@@ -91,6 +91,7 @@ class ViewRecyclerTests: XCTestCase {
         XCTAssertNotNil(one.superview)
     }
 
+    #if os(iOS) || os(tvOS)
     func testReusedViewTransformReset() {
         let root = View()
         let one = View(viewReuseId: "1")
@@ -107,7 +108,6 @@ class ViewRecyclerTests: XCTestCase {
 
     /// Test for safe subview-purge in composite view e.g. UIButton.
     /// - SeeAlso: https://github.com/linkedin/LayoutKit/pull/85
-    #if os(iOS) || os(tvOS)
     func testRecycledCompositeView() {
         let root = View()
         let button = UIButton(viewReuseId: "1")

--- a/LayoutKitTests/ViewRecyclerTests.swift
+++ b/LayoutKitTests/ViewRecyclerTests.swift
@@ -92,10 +92,16 @@ class ViewRecyclerTests: XCTestCase {
     }
 
     #if os(iOS) || os(tvOS)
-    func testReusedViewTransformReset() {
+    /// Test that a reused view's frame shouldn't change if its transform and layer anchor point
+    /// get set to the default values.
+    /// - SeeAlso: https://github.com/linkedin/LayoutKit/pull/231
+    func testReusedViewFrame() {
         let root = View()
         let one = View(viewReuseId: "1")
         one.transform = CGAffineTransform(scaleX: 0.001, y: 0.001)
+        one.layer.anchorPoint = CGPoint(x: 0, y: 0)
+        let frame = CGRect(x: 0, y: 0, width: 200, height: 100)
+        one.frame = frame
         root.addSubview(one)
 
         let recycler = ViewRecycler(rootView: root)
@@ -104,6 +110,12 @@ class ViewRecyclerTests: XCTestCase {
             return View()
         })
         XCTAssertTrue(v?.transform == CGAffineTransform.identity)
+        XCTAssertTrue(v?.layer.anchorPoint == CGPoint(x: 0.5, y: 0.5))
+
+        one.frame = frame
+        one.transform = CGAffineTransform.identity
+        one.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        XCTAssertTrue(one.frame == frame)
     }
 
     /// Test for safe subview-purge in composite view e.g. UIButton.

--- a/LayoutKitTests/ViewRecyclerTests.swift
+++ b/LayoutKitTests/ViewRecyclerTests.swift
@@ -91,6 +91,20 @@ class ViewRecyclerTests: XCTestCase {
         XCTAssertNotNil(one.superview)
     }
 
+    func testReusedViewTransformReset() {
+        let root = View()
+        let one = View(viewReuseId: "1")
+        one.transform = CGAffineTransform(scaleX: 0.001, y: 0.001)
+        root.addSubview(one)
+
+        let recycler = ViewRecycler(rootView: root)
+        let v: View? = recycler.makeOrRecycleView(havingViewReuseId: "1", viewProvider: {
+            XCTFail("view should have been recycled")
+            return View()
+        })
+        XCTAssertTrue(v?.transform == CGAffineTransform.identity)
+    }
+
     /// Test for safe subview-purge in composite view e.g. UIButton.
     /// - SeeAlso: https://github.com/linkedin/LayoutKit/pull/85
     #if os(iOS) || os(tvOS)

--- a/Sources/ViewRecycler.swift
+++ b/Sources/ViewRecycler.swift
@@ -23,6 +23,8 @@ class ViewRecycler {
 
     private var viewsById = [String: View]()
     private var unidentifiedViews = Set<View>()
+    private let defaultLayerAnchorPoint = CGPoint(x: 0.5, y: 0.5)
+    private let defaultTransform = CGAffineTransform.identity
 
     /// Retains all subviews of rootView for recycling.
     init(rootView: View?) {
@@ -60,8 +62,13 @@ class ViewRecycler {
             // 4. View's transform gets set to identity in a config block.
             // 5. One would expect view's frame to be (0, 0, 100, 100) since its transform is now identity. But actually its frame will be
             //    (-49950, -49950, 100000, 100000) because its scale has just gone up 1000-fold, i.e. from 0.001 to 1.
-            view.transform = CGAffineTransform.identity
-            view.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+            if view.layer.anchorPoint != defaultLayerAnchorPoint {
+                view.layer.anchorPoint = defaultLayerAnchorPoint
+            }
+
+            if view.transform != defaultTransform {
+                view.transform = defaultTransform
+            }
             #endif
 
             return view

--- a/Sources/ViewRecycler.swift
+++ b/Sources/ViewRecycler.swift
@@ -8,7 +8,9 @@
 
 import ObjectiveC
 import Foundation
+#if os(iOS) || os(tvOS)
 import UIKit
+#endif
 
 /**
  Provides APIs to recycle views by id.
@@ -41,6 +43,8 @@ class ViewRecycler {
         // If we have a recyclable view that matches type and id, then reuse it.
         if let viewReuseId = viewReuseId, let view = viewsById[viewReuseId] {
             viewsById[viewReuseId] = nil
+
+            #if os(iOS) || os(tvOS)
             // Reset affine transformation. Without this there will be an issue when transform is set on a reused view that already
             // has a non-identity transform. The issue goes like this.
             // 1. View has a non-identity transform.
@@ -56,6 +60,8 @@ class ViewRecycler {
             // 5. One would expect view's frame to be (0, 0, 100, 100) since its transform is now identity. But actually its frame will be
             //    (-49950, -49950, 100000, 100000) because its scale has just gone up 1000-fold, i.e. from 0.001 to 1.
             view.transform = CGAffineTransform.identity
+            #endif
+
             return view
         }
 

--- a/Sources/ViewRecycler.swift
+++ b/Sources/ViewRecycler.swift
@@ -23,8 +23,10 @@ class ViewRecycler {
 
     private var viewsById = [String: View]()
     private var unidentifiedViews = Set<View>()
+    #if os(iOS) || os(tvOS)
     private let defaultLayerAnchorPoint = CGPoint(x: 0.5, y: 0.5)
     private let defaultTransform = CGAffineTransform.identity
+    #endif
 
     /// Retains all subviews of rootView for recycling.
     init(rootView: View?) {

--- a/Sources/ViewRecycler.swift
+++ b/Sources/ViewRecycler.swift
@@ -45,8 +45,9 @@ class ViewRecycler {
             viewsById[viewReuseId] = nil
 
             #if os(iOS) || os(tvOS)
-            // Reset affine transformation. Without this there will be an issue when transform is set on a reused view that already
-            // has a non-identity transform. The issue goes like this.
+            // Reset affine transformation and layer anchor point to their default values.
+            // Without this there will be an issue when their current value is not the default.
+            // Take affine transformation for example, the issue goes like this.
             // 1. View has a non-identity transform.
             // 2. View gets retrieved from the viewsById map.
             // 3. View's frame gets set under the assumption that its transform is identity.
@@ -60,6 +61,7 @@ class ViewRecycler {
             // 5. One would expect view's frame to be (0, 0, 100, 100) since its transform is now identity. But actually its frame will be
             //    (-49950, -49950, 100000, 100000) because its scale has just gone up 1000-fold, i.e. from 0.001 to 1.
             view.transform = CGAffineTransform.identity
+            view.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
             #endif
 
             return view


### PR DESCRIPTION
Please note: The changes are limited to iOS and tvOS only. For macOS, we will probably have to reset NSView's layer.sublayerTransform. But I can't really test that change so I will leave it out for now.

Reset affine transformation and layer anchor point to their default values. Without this there will be an issue when their current value is not the default. 

Take affine transformation for example, the issue goes like this.
1. View has a non-identity transform.
2. View gets retrieved from the viewsById map.
3. View's frame gets set under the assumption that its transform is identity.
4. View's transform gets set to a value.
5. View's frame gets changed automatically when its transform gets set. As a result, view's frame will not match its transform.

Example:
1. View has a scale transform of (0.001, 0.001).
2. View gets reused so its transform is still (0.001, 0.001).
3. View's frame gets set to (0, 0, 100, 100) which is its original size.
4. View's transform gets set to identity in a config block.
5. One would expect view's frame to be (0, 0, 100, 100) since its transform is now identity. But actually its frame will be (-49950, -49950, 100000, 100000) because its scale has just gone up 1000-fold, i.e. from 0.001 to 1.