### PR TITLE
Fix two flexibility issues

### DIFF
--- a/Sources/Layouts/InsetLayout.swift
+++ b/Sources/Layouts/InsetLayout.swift
@@ -19,23 +19,25 @@ open class InsetLayout<V: View>: BaseLayout<V>, ConfigurableLayout {
 
     public init(insets: EdgeInsets,
                 alignment: Alignment = Alignment.fill,
+                flexibility: Flexibility? = nil,
                 viewReuseId: String? = nil,
                 sublayout: Layout,
                 config: ((V) -> Void)? = nil) {
         self.insets = insets
         self.sublayout = sublayout
-        super.init(alignment: alignment, flexibility: sublayout.flexibility, viewReuseId: viewReuseId, config: config)
+        super.init(alignment: alignment, flexibility: flexibility ?? sublayout.flexibility, viewReuseId: viewReuseId, config: config)
     }
 
     init(insets: EdgeInsets,
          alignment: Alignment = Alignment.fill,
+         flexibility: Flexibility? = nil,
          viewReuseId: String? = nil,
          sublayout: Layout,
          viewClass: V.Type?,
          config: ((V) -> Void)? = nil) {
         self.insets = insets
         self.sublayout = sublayout
-        super.init(alignment: alignment, flexibility: sublayout.flexibility, viewReuseId: viewReuseId, viewClass: viewClass ?? V.self, config: config)
+        super.init(alignment: alignment, flexibility: flexibility ?? sublayout.flexibility, viewReuseId: viewReuseId, viewClass: viewClass ?? V.self, config: config)
     }
 
     public convenience init(inset: CGFloat,

--- a/Sources/ObjCSupport/Builders/LOKInsetLayoutBuilder.h
+++ b/Sources/ObjCSupport/Builders/LOKInsetLayoutBuilder.h
@@ -18,6 +18,7 @@
 + (nonnull instancetype)withInsets:(LOKEdgeInsets)insets around:(nonnull id<LOKLayout>)sublayout;
 
 @property (nonatomic, nonnull, readonly) LOKInsetLayoutBuilder * _Nonnull(^alignment)(LOKAlignment * _Nullable);
+@property (nonatomic, nonnull, readonly) LOKInsetLayoutBuilder * _Nonnull(^flexibility)(LOKFlexibility * _Nullable);
 @property (nonatomic, nonnull, readonly) LOKInsetLayoutBuilder * _Nonnull(^viewReuseId)(NSString * _Nullable);
 @property (nonatomic, nonnull, readonly) LOKInsetLayoutBuilder * _Nonnull(^viewClass)(Class _Nullable);
 

--- a/Sources/ObjCSupport/Builders/LOKInsetLayoutBuilder.m
+++ b/Sources/ObjCSupport/Builders/LOKInsetLayoutBuilder.m
@@ -39,6 +39,7 @@
 - (nonnull LOKInsetLayout *)layout {
     return [[LOKInsetLayout alloc] initWithInsets:self.privateInsets
                                         alignment:self.privateAlignment
+                                      flexibility:self.privateFlexibility
                                       viewReuseId:self.privateViewReuseId
                                         viewClass:self.privateViewClass
                                         sublayout:self.privateSublayout

--- a/Sources/ObjCSupport/Builders/LOKInsetLayoutBuilder.m
+++ b/Sources/ObjCSupport/Builders/LOKInsetLayoutBuilder.m
@@ -13,6 +13,7 @@
 @interface LOKInsetLayoutBuilder()
 
 @property (nonatomic, nullable) LOKAlignment *privateAlignment;
+@property (nonatomic, nullable) LOKFlexibility *privateFlexibility;
 @property (nonatomic, nullable) NSString *privateViewReuseId;
 @property (nonatomic, nullable) Class privateViewClass;
 
@@ -48,6 +49,13 @@
 - (LOKInsetLayoutBuilder * _Nonnull (^)(LOKAlignment * _Nonnull))alignment {
     return ^LOKInsetLayoutBuilder *(LOKAlignment * alignment){
         self.privateAlignment = alignment;
+        return self;
+    };
+}
+
+- (LOKInsetLayoutBuilder * _Nonnull (^)(LOKFlexibility * _Nonnull))flexibility {
+    return ^LOKInsetLayoutBuilder *(LOKFlexibility * flexibility){
+        self.privateFlexibility = flexibility;
         return self;
     };
 }

--- a/Sources/ObjCSupport/Builders/LOKOverlayLayoutBuilder.m
+++ b/Sources/ObjCSupport/Builders/LOKOverlayLayoutBuilder.m
@@ -43,6 +43,7 @@
                                           backgroundLayouts:self.privateBackground
                                              overlayLayouts:self.privateOverlay
                                                   alignment:self.privateAlignment
+                                                flexibility:self.privateFlexibility
                                                 viewReuseId:self.privateViewReuseId
                                                   viewClass:self.privateViewClass
                                                   configure:self.privateConfigure];

--- a/Sources/ObjCSupport/LOKInsetLayout.swift
+++ b/Sources/ObjCSupport/LOKInsetLayout.swift
@@ -11,7 +11,7 @@ import CoreGraphics
 @objc open class LOKInsetLayout: LOKBaseLayout {
     @objc public let insets: EdgeInsets
     @objc public let alignment: LOKAlignment
-    @objc public let flexibility: LOKFlexibility?
+    @objc public let flexibility: LOKFlexibility
     @objc public let viewClass: View.Type
     @objc public let sublayout: LOKLayout
     @objc public let configure: ((View) -> Void)?
@@ -26,7 +26,7 @@ import CoreGraphics
         self.insets = insets
         self.sublayout = sublayout
         self.alignment = alignment ?? .fill
-        self.flexibility = flexibility
+        self.flexibility = flexibility ?? sublayout.flexibility
         self.viewClass = viewClass ?? View.self
         self.configure = configure
         let layout = InsetLayout(

--- a/Sources/ObjCSupport/LOKInsetLayout.swift
+++ b/Sources/ObjCSupport/LOKInsetLayout.swift
@@ -11,12 +11,14 @@ import CoreGraphics
 @objc open class LOKInsetLayout: LOKBaseLayout {
     @objc public let insets: EdgeInsets
     @objc public let alignment: LOKAlignment
+    @objc public let flexibility: LOKFlexibility?
     @objc public let viewClass: View.Type
     @objc public let sublayout: LOKLayout
     @objc public let configure: ((View) -> Void)?
 
     @objc public init(insets: EdgeInsets,
                       alignment: LOKAlignment? = nil,
+                      flexibility: LOKFlexibility? =nil,
                       viewReuseId: String? = nil,
                       viewClass: View.Type? = nil,
                       sublayout: LOKLayout,
@@ -24,11 +26,13 @@ import CoreGraphics
         self.insets = insets
         self.sublayout = sublayout
         self.alignment = alignment ?? .fill
+        self.flexibility = flexibility
         self.viewClass = viewClass ?? View.self
         self.configure = configure
         let layout = InsetLayout(
             insets: self.insets,
             alignment: self.alignment.alignment,
+            flexibility: self.flexibility
             viewReuseId: viewReuseId,
             sublayout: self.sublayout.unwrapped,
             viewClass: self.viewClass,

--- a/Sources/ObjCSupport/LOKInsetLayout.swift
+++ b/Sources/ObjCSupport/LOKInsetLayout.swift
@@ -11,14 +11,13 @@ import CoreGraphics
 @objc open class LOKInsetLayout: LOKBaseLayout {
     @objc public let insets: EdgeInsets
     @objc public let alignment: LOKAlignment
-    @objc public let flexibility: LOKFlexibility
     @objc public let viewClass: View.Type
     @objc public let sublayout: LOKLayout
     @objc public let configure: ((View) -> Void)?
 
     @objc public init(insets: EdgeInsets,
                       alignment: LOKAlignment? = nil,
-                      flexibility: LOKFlexibility? =nil,
+                      flexibility: LOKFlexibility? = nil,
                       viewReuseId: String? = nil,
                       viewClass: View.Type? = nil,
                       sublayout: LOKLayout,
@@ -26,13 +25,12 @@ import CoreGraphics
         self.insets = insets
         self.sublayout = sublayout
         self.alignment = alignment ?? .fill
-        self.flexibility = flexibility ?? sublayout.flexibility
         self.viewClass = viewClass ?? View.self
         self.configure = configure
         let layout = InsetLayout(
             insets: self.insets,
             alignment: self.alignment.alignment,
-            flexibility: self.flexibility
+            flexibility: flexibility?.flexibility,
             viewReuseId: viewReuseId,
             sublayout: self.sublayout.unwrapped,
             viewClass: self.viewClass,

--- a/Sources/ObjCSupport/LOKOverlayLayout.swift
+++ b/Sources/ObjCSupport/LOKOverlayLayout.swift
@@ -20,6 +20,7 @@ import Foundation
                       backgroundLayouts: [LOKLayout]? = nil,
                       overlayLayouts: [LOKLayout]? = nil,
                       alignment: LOKAlignment? = nil,
+                      flexibility: LOKFlexibility? = nil,
                       viewReuseId: String? = nil,
                       viewClass: View.Type? = nil,
                       configure: ((View) -> Void)? = nil) {
@@ -34,6 +35,7 @@ import Foundation
             backgroundLayouts: backgroundLayouts?.map { $0.unwrapped } ?? [],
             overlayLayouts: overlayLayouts?.map { $0.unwrapped } ?? [],
             alignment: self.alignment.alignment,
+            flexibility: flexibility?.flexibility ?? .flexible,
             viewReuseId: viewReuseId,
             viewClass: self.viewClass,
             config: self.configure))


### PR DESCRIPTION
1. LOKOverlayLayoutBuilder's "flexibility" block property doesn't have any effect. To fix it, we pass privateFlexibility to LOKOverlayLayout constructor.
2. LOKInsetLayoutBuilder's "flexibility" block property doesn't have any effect because InsetLayout always takes its sublayout's flexibility as its own flexibility. To fix it, we have InsetLayout constructor take in a flexibility parameter and only use its sublayout's flexibility when that parameter is nil.
