### PR TITLE
Default to the first primary layout's flexibility for OverlayLayout

### DIFF
--- a/Sources/ObjCSupport/LOKOverlayLayout.swift
+++ b/Sources/ObjCSupport/LOKOverlayLayout.swift
@@ -35,7 +35,7 @@ import Foundation
             backgroundLayouts: backgroundLayouts?.map { $0.unwrapped } ?? [],
             overlayLayouts: overlayLayouts?.map { $0.unwrapped } ?? [],
             alignment: self.alignment.alignment,
-            flexibility: flexibility?.flexibility ?? .flexible,
+            flexibility: flexibility?.flexibility ?? primaryLayouts.first?.flexibility.flexibility ?? .flexible,
             viewReuseId: viewReuseId,
             viewClass: self.viewClass,
             config: self.configure))


### PR DESCRIPTION
For OverlayLayout, if flexibility is specified in the constructor, use it.
Otherwise, if the first primary layout's flexibility is specified, use it.
Otherwise, use .flexible as its flexibility.

This change is made to maintain backwards compatibility with 9.0.0.