### PR TITLE
Bumping version to 10.0.1

### DIFF
--- a/LayoutKit.podspec
+++ b/LayoutKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name              = 'LayoutKit'
-  spec.version           = '10.0.0'
+  spec.version           = '10.0.1'
   spec.license           = { :type => 'Apache License, Version 2.0' }
   spec.homepage          = 'http://layoutkit.org'
   spec.authors           = 'LinkedIn'

--- a/LayoutKitObjC.podspec
+++ b/LayoutKitObjC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name              = 'LayoutKitObjC'
-  spec.version           = '10.0.0'
+  spec.version           = '10.0.1'
   spec.license           = { :type => 'Apache License, Version 2.0' }
   spec.homepage          = 'http://layoutkit.org'
   spec.authors           = 'LinkedIn'

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>10.0.0</string>
+	<string>10.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Bugfix version fixes handling of flexibility on Overlay and Inset layouts.
OverlayLayout now has an optional flexibility parameter, and defaults to the flexibility of the first primary layout.
InsetLayout now has an optional flexibility parameter, and the corresponding builder’s flexibility parameter is now hooked up whereas it had no effect before.