### PR TITLE
Fix a recycling bug that purges indirect subviews

### DIFF
--- a/LayoutKitTests/ViewRecyclerTests.swift
+++ b/LayoutKitTests/ViewRecyclerTests.swift
@@ -91,6 +91,30 @@ class ViewRecyclerTests: XCTestCase {
         XCTAssertNotNil(one.superview)
     }
 
+    func testRecycledViewWithoutPurgingIndirectSubviews() {
+        let root = View()
+        let headerView = View()
+        headerView.isLayoutKitView = true
+        root.addSubview(headerView)
+        let titleView = View(viewReuseId: "1")
+        root.addSubview(titleView)
+        let collectionView = View()
+        let cellView = View()
+        cellView.isLayoutKitView = true
+        root.addSubview(collectionView)
+        collectionView.addSubview(cellView)
+
+        let recycler = ViewRecycler(rootView: root)
+        let _ = recycler.makeOrRecycleView(havingViewReuseId: nil, viewProvider: {
+            return View()
+        })
+
+        recycler.purgeViews()
+        XCTAssertNil(headerView.superview)
+        XCTAssertNil(titleView.superview)
+        XCTAssertNotNil(cellView.superview)
+    }
+
     #if os(iOS) || os(tvOS)
     /// Test that a reused view's frame shouldn't change if its transform and layer anchor point
     /// get set to the default values.

--- a/Sources/ViewRecycler.swift
+++ b/Sources/ViewRecycler.swift
@@ -28,14 +28,18 @@ class ViewRecycler {
     private let defaultTransform = CGAffineTransform.identity
     #endif
 
-    /// Retains all subviews of rootView for recycling.
+    /// Retains all LayoutKit subviews of rootView for recycling.
     init(rootView: View?) {
-        rootView?.walkSubviews { (view) in
+        let visitor: (View) -> Void = { view in
             if let viewReuseId = view.viewReuseId {
                 self.viewsById[viewReuseId] = view
             } else {
                 self.unidentifiedViews.insert(view)
             }
+        }
+        rootView?.subviews.filter({$0.isLayoutKitView || $0.viewReuseId != nil}).forEach { (view) in
+            visitor(view)
+            view.walkSubviews(visitor: visitor)
         }
     }
 


### PR DESCRIPTION
Only walk first level of subviews that are created by LayoutKit.
If a subview isn't created by LayoutKit, then there is no need to walk
subviews of it, as they must not be created by this layout.