### PR TITLE
Update SwiftPM manifest to work with Accio

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,7 @@ let package = Package(
     targets: [
         .target(
             name: "LayoutKit",
-            path: "Sources",
-            exclude: ["Sources/ObjCSupport"]
+            path: "Sources/Internal"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
     targets: [
         .target(
             name: "LayoutKit",
-            path: "Sources"
+            path: "Sources",
+            exclude: ["Sources/ObjCSupport"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,16 @@
-// Copyright 2017 LinkedIn Corp.
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-// swift-tools-version:3.1
-
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(
-    name: "LayoutKit"
+    name: "LayoutKit",
+    // platforms: [.iOS("8.0"), .macOS("10.10"), tvOS("9.0")],
+    products: [
+        .library(name: "LayoutKit", targets: ["LayoutKit"])
+    ],
+    targets: [
+        .target(
+            name: "LayoutKit",
+            path: "Sources"
+        )
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then run `carthage update`.
 
 Add this to your Package.swift:
 ```swift
-.package(url: "https://github.com/AccioSupport/LayoutKit.git", .upToNextMajor(from: "")),
+.package(url: "https://github.com/AccioSupport/LayoutKit.git", .upToNextMajor(from: "10.1.0")),
 ```
 
 Next, add `LayoutKit` to your App targets dependencies like so:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then run `carthage update`.
 
 Add this to your Package.swift:
 ```swift
-.package(url: "https://github.com/AccioSupport/LayoutKit.git", .upToNextMajor(from: "10.1.0")),
+.package(url: "https://github.com/linkedin/LayoutKit.git", .upToNextMajor(from: "10.1.0")),
 ```
 
 Next, add `LayoutKit` to your App targets dependencies like so:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We have found LayoutKit to be a useful tool, but you should be aware of what it 
 
 ## Installation
 
-LayoutKit can be installed with [CocoaPods](https://cocoapods.org/) or [Carthage](https://github.com/Carthage/Carthage).
+LayoutKit can be installed with [CocoaPods](https://cocoapods.org/), [Carthage](https://github.com/Carthage/Carthage) or [Accio](https://github.com/JamitLabs/Accio).
 
 ### CocoaPods
 
@@ -79,6 +79,25 @@ github "linkedin/LayoutKit"
 ```
 
 Then run `carthage update`.
+
+### Accio
+
+Add this to your Package.swift:
+```swift
+.package(url: "https://github.com/AccioSupport/LayoutKit.git", .upToNextMajor(from: "")),
+```
+
+Next, add `LayoutKit` to your App targets dependencies like so:
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "LayoutKit",
+    ]
+),
+```
+
+Then run `accio update`.
 
 ## Documentation
 


### PR DESCRIPTION
This updates support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).