### PR TITLE
Fixed Potential truncation issue in LabelLayout

### DIFF
--- a/Sources/Internal/NSAttributedStringExtension.swift
+++ b/Sources/Internal/NSAttributedStringExtension.swift
@@ -12,16 +12,18 @@ extension NSAttributedString {
 
     /// Returns a new NSAttributedString with a given font and the same attributes.
     func with(font: UIFont) -> NSAttributedString {
-        let fontAttribute = [NSAttributedString.Key.font: font]
-        let attributedTextWithFont = NSMutableAttributedString(string: string, attributes: fontAttribute)
-        let fullRange = NSMakeRange(0, (string as NSString).length)
-        attributedTextWithFont.beginEditing()
-        self.enumerateAttributes(in: fullRange, options: .longestEffectiveRangeNotRequired, using: { (attributes, range, _) in
-            attributedTextWithFont.addAttributes(attributes, range: range)
-        })
-        attributedTextWithFont.endEditing()
-
-        return attributedTextWithFont
+        return with(additionalAttributes: [NSAttributedString.Key.font: font])
     }
 
+    /// Returns a new NSAttributedString with previous as well as additional attributes.
+    func with(additionalAttributes: [NSAttributedString.Key : Any]?) -> NSAttributedString {
+        let attributedTextWithAdditionalAttributes = NSMutableAttributedString(string: string, attributes: additionalAttributes)
+        let fullRange = NSMakeRange(0, (string as NSString).length)
+        attributedTextWithAdditionalAttributes.beginEditing()
+        self.enumerateAttributes(in: fullRange, options: .longestEffectiveRangeNotRequired, using: { (attributes, range, _) in
+            attributedTextWithAdditionalAttributes.addAttributes(attributes, range: range)
+        })
+        attributedTextWithAdditionalAttributes.endEditing()
+        return attributedTextWithAdditionalAttributes
+    }
 }

--- a/Sources/Layouts/LabelLayout.swift
+++ b/Sources/Layouts/LabelLayout.swift
@@ -17,11 +17,13 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
     public let font: UIFont
     public let numberOfLines: Int
     public let lineHeight: CGFloat
+    public let lineBreakMode: NSLineBreakMode
 
     public init(text: Text,
                 font: UIFont = LabelLayoutDefaults.defaultFont,
                 lineHeight: CGFloat? = nil,
                 numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
+                lineBreakMode: NSLineBreakMode = LabelLayoutDefaults.defaultLineBreakMode,
                 alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
                 flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
                 viewReuseId: String? = nil,
@@ -31,6 +33,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
         self.numberOfLines = numberOfLines
         self.font = font
         self.lineHeight = lineHeight ?? font.lineHeight
+        self.lineBreakMode = lineBreakMode
         super.init(alignment: alignment, flexibility: flexibility, viewReuseId: viewReuseId, config: config)
     }
 
@@ -38,6 +41,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
          font: UIFont = LabelLayoutDefaults.defaultFont,
          lineHeight: CGFloat? = nil,
          numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
+         lineBreakMode: NSLineBreakMode = LabelLayoutDefaults.defaultLineBreakMode,
          alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
          flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
          viewReuseId: String? = nil,
@@ -48,6 +52,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
         self.numberOfLines = numberOfLines
         self.font = font
         self.lineHeight = lineHeight ?? font.lineHeight
+        self.lineBreakMode = lineBreakMode
         super.init(alignment: alignment, flexibility: flexibility, viewReuseId: viewReuseId, viewClass: viewClass ?? Label.self, config: config)
     }
 
@@ -55,6 +60,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
          font: UIFont = LabelLayoutDefaults.defaultFont,
          lineHeight: CGFloat? = nil,
          numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
+         lineBreakMode: NSLineBreakMode = LabelLayoutDefaults.defaultLineBreakMode,
          alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
          flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
          viewReuseId: String? = nil,
@@ -65,6 +71,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
         self.numberOfLines = numberOfLines
         self.font = font
         self.lineHeight = lineHeight ?? font.lineHeight
+        self.lineBreakMode = lineBreakMode
         super.init(alignment: alignment, flexibility: flexibility, viewReuseId: viewReuseId, viewClass: viewClass ?? Label.self, config: config)
     }
 
@@ -74,6 +81,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
                             font: UIFont = LabelLayoutDefaults.defaultFont,
                             lineHeight: CGFloat? = nil,
                             numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
+                            lineBreakMode: NSLineBreakMode = LabelLayoutDefaults.defaultLineBreakMode,
                             alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
                             flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
                             viewReuseId: String? = nil,
@@ -83,6 +91,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
                   font: font,
                   lineHeight: lineHeight,
                   numberOfLines: numberOfLines,
+                  lineBreakMode: lineBreakMode,
                   alignment: alignment,
                   flexibility: flexibility,
                   viewReuseId: viewReuseId,
@@ -93,6 +102,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
                             font: UIFont = LabelLayoutDefaults.defaultFont,
                             lineHeight: CGFloat? = nil,
                             numberOfLines: Int = LabelLayoutDefaults.defaultNumberOfLines,
+                            lineBreakMode: NSLineBreakMode = LabelLayoutDefaults.defaultLineBreakMode,
                             alignment: Alignment = LabelLayoutDefaults.defaultAlignment,
                             flexibility: Flexibility = LabelLayoutDefaults.defaultFlexibility,
                             viewReuseId: String? = nil,
@@ -102,6 +112,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
                   font: font,
                   lineHeight: lineHeight,
                   numberOfLines: numberOfLines,
+                  lineBreakMode: lineBreakMode,
                   alignment: alignment,
                   flexibility: flexibility,
                   viewReuseId: viewReuseId,
@@ -116,7 +127,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
     }
 
     private func textSize(within maxSize: CGSize) -> CGSize {
-        var size = text.textSize(within: maxSize, font: font)
+        var size = text.textSize(within: maxSize, font: font, lineBreakMode: lineBreakMode)
         if numberOfLines > 0 {
             let maxHeight = (CGFloat(numberOfLines) * lineHeight).roundedUpToFractionalPoint
             if size.height > maxHeight {
@@ -134,6 +145,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
     open override func configure(view label: Label) {
         config?(label)
         label.numberOfLines = numberOfLines
+        label.lineBreakMode = lineBreakMode
         label.font = font
         switch text {
         case .unattributed(let text):
@@ -155,6 +167,7 @@ public class LabelLayoutDefaults {
     public static let defaultNumberOfLines = 0
     public static let defaultFont = UILabel().font ?? UIFont.systemFont(ofSize: 17)
     public static let defaultAlignment = Alignment.topLeading
+    public static let defaultLineBreakMode = NSLineBreakMode.byTruncatingTail
     public static let defaultFlexibility = Flexibility.flexible
 }
 

--- a/Sources/ObjCSupport/Builders/LOKLabelLayoutBuilder.h
+++ b/Sources/ObjCSupport/Builders/LOKLabelLayoutBuilder.h
@@ -43,6 +43,11 @@
 @property (nonatomic, nonnull, readonly) LOKLabelLayoutBuilder * _Nonnull(^numberOfLines)(NSInteger);
 
 /**
+ @c LOKLabelLayoutBuilder block for setting line break mode of the label.
+ */
+@property (nonatomic, nonnull, readonly) LOKLabelLayoutBuilder * _Nonnull(^lineBreakMode)(NSLineBreakMode);
+
+/**
  @c LOKLabelLayoutBuilder block for setting line height of the label.
  */
 @property (nonatomic, nonnull, readonly) LOKLabelLayoutBuilder * _Nonnull(^lineHeight)(CGFloat);

--- a/Sources/ObjCSupport/Builders/LOKLabelLayoutBuilder.m
+++ b/Sources/ObjCSupport/Builders/LOKLabelLayoutBuilder.m
@@ -21,6 +21,7 @@
 @property (nonatomic, nullable) NSAttributedString *privateAttributedString;
 @property (nonatomic, nullable) UIFont *privateFont;
 @property (nonatomic) NSInteger privateNumberOfLines;
+@property (nonatomic) NSLineBreakMode privateLineBreakMode;
 @property (nonatomic) CGFloat privateLineHeight;
 @property (nonatomic, nullable) void (^ privateConfigure)(UILabel * _Nonnull);
 
@@ -31,12 +32,14 @@
 - (instancetype)initWithString:(NSString *)string {
     self = [super init];
     _privateString = string;
+    _privateLineBreakMode = NSLineBreakByTruncatingTail;
     return self;
 }
 
 - (instancetype)initWithAttributedString:(NSAttributedString *)attributedString {
     self = [super init];
     _privateAttributedString = attributedString;
+    _privateLineBreakMode = NSLineBreakByTruncatingTail;
     return self;
 }
 
@@ -53,6 +56,7 @@
     if (self.privateAttributedString) {
         return [[LOKLabelLayout alloc] initWithAttributedString:self.privateAttributedString
                                                            font:self.privateFont
+                                                  lineBreakMode:self.privateLineBreakMode
                                                      lineHeight:self.privateLineHeight
                                                   numberOfLines:self.privateNumberOfLines
                                                       alignment:self.privateAlignment
@@ -63,6 +67,7 @@
     } else {
         return [[LOKLabelLayout alloc] initWithString:self.privateString
                                                  font:self.privateFont
+                                        lineBreakMode:self.privateLineBreakMode
                                            lineHeight:self.privateLineHeight
                                         numberOfLines:self.privateNumberOfLines
                                             alignment:self.privateAlignment
@@ -83,6 +88,13 @@
 - (LOKLabelLayoutBuilder * _Nonnull (^)(NSInteger))numberOfLines {
     return ^LOKLabelLayoutBuilder *(NSInteger numberOfLines){
         self.privateNumberOfLines = numberOfLines;
+        return self;
+    };
+}
+
+- (LOKLabelLayoutBuilder * _Nonnull (^)(NSLineBreakMode))lineBreakMode {
+    return ^LOKLabelLayoutBuilder *(NSLineBreakMode lineBreakMode){
+        self.privateLineBreakMode = lineBreakMode;
         return self;
     };
 }

--- a/Sources/ObjCSupport/LOKLabelLayout.swift
+++ b/Sources/ObjCSupport/LOKLabelLayout.swift
@@ -34,6 +34,11 @@ import UIKit
     @objc public let font: UIFont
 
     /**
+     Line break mode for label.
+     */
+    @objc public let lineBreakMode: NSLineBreakMode
+
+    /**
      Number of lines the label can have.
      */
     @objc public let numberOfLines: Int
@@ -55,6 +60,7 @@ import UIKit
 
     @objc public init(attributedString: NSAttributedString,
                       font: UIFont?,
+                      lineBreakMode: NSLineBreakMode,
                       lineHeight: CGFloat,
                       numberOfLines: Int,
                       alignment: LOKAlignment?,
@@ -64,6 +70,7 @@ import UIKit
                       configure: ((UILabel) -> Void)?) {
         self.attributedString = attributedString
         self.font = font ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
+        self.lineBreakMode = lineBreakMode
         self.lineHeight = lineHeight
         self.numberOfLines = numberOfLines
         self.alignment = alignment ?? .topLeading
@@ -75,6 +82,7 @@ import UIKit
             font: self.font,
             lineHeight: lineHeight > 0 && lineHeight.isFinite ? lineHeight : Optional<CGFloat>.none,
             numberOfLines: self.numberOfLines,
+            lineBreakMode: self.lineBreakMode,
             alignment: self.alignment.alignment,
             flexibility: flexibility?.flexibility ?? .flexible,
             viewReuseId: viewReuseId,
@@ -86,6 +94,7 @@ import UIKit
 
     @objc public init(string: String,
                       font: UIFont?,
+                      lineBreakMode: NSLineBreakMode,
                       lineHeight: CGFloat,
                       numberOfLines: Int,
                       alignment: LOKAlignment?,
@@ -95,6 +104,7 @@ import UIKit
                       configure: ((UILabel) -> Void)?) {
         self.string = string
         self.font = font ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
+        self.lineBreakMode = lineBreakMode
         self.lineHeight = lineHeight
         self.numberOfLines = numberOfLines
         self.alignment = alignment ?? .topLeading
@@ -106,6 +116,7 @@ import UIKit
             font: self.font,
             lineHeight: lineHeight > 0 && lineHeight.isFinite ? lineHeight : Optional<CGFloat>.none,
             numberOfLines: self.numberOfLines,
+            lineBreakMode: self.lineBreakMode,
             alignment: self.alignment.alignment,
             flexibility: flexibility?.flexibility ?? .flexible,
             viewReuseId: viewReuseId,

--- a/Sources/Text.swift
+++ b/Sources/Text.swift
@@ -13,12 +13,30 @@ public enum Text {
     case unattributed(String)
     case attributed(NSAttributedString)
 
-    /// Calculate the text size within `maxSize` by given `UIFont`
+    /// Calculate the text size within `maxSize` by given `UIFont` and `NSLineBreakMode`
     func textSize(within maxSize: CGSize,
-                  font: UIFont) -> CGSize {
+                  font: UIFont,
+                  lineBreakMode: NSLineBreakMode = .byTruncatingTail) -> CGSize {
         let options: NSStringDrawingOptions = [
             .usesLineFragmentOrigin
         ]
+
+
+        // By default `boundingRect(with:options:attributes:)` seems to be using `lineBreakMode=byWordWrapping` to calculate size,
+        // so if UILabel/UITextView's mode is char wrapping, we may get more height than required.
+        // So use `paragraphStyle` only in case when UILabel/UITextView's mode is `byCharWrapping` because if we use `paragraphStyle`
+        // with `byTruncatingTail`, `boundingRect(with:options:attributes:)` always give single line height.
+        let attributes: [NSAttributedString.Key: Any] = {
+            if lineBreakMode == .byCharWrapping {
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.lineBreakMode = lineBreakMode
+                return [
+                    NSAttributedString.Key.font: font,
+                    NSAttributedString.Key.paragraphStyle: paragraphStyle
+                ]
+            }
+            return [NSAttributedString.Key.font: font]
+        }()
 
         let size: CGSize
         switch self {
@@ -27,19 +45,19 @@ public enum Text {
                 return .zero
             }
 
-            // UILabel/UITextView uses a default font if one is not specified in the attributed string.
+            // UILabel/UITextView uses a default font and lineBreakMode if one is not specified in the attributed string.
             // boundingRect(with:options:attributes:) does not appear to have the same logic,
-            // so we need to ensure that our attributed string has a default font.
-            // We do this by creating a new attributed string with the default font and then
+            // so we need to ensure that our attributed string has a default font and lineBreakMode.
+            // We do this by creating a new attributed string with the default font & lineBreakMode and then
             // applying all of the attributes from the provided attributed string.
-            let fontAppliedAttributeString = attributedText.with(font: font)
+            let newAttributedString = attributedText.with(additionalAttributes: attributes)
 
-            size = fontAppliedAttributeString.boundingRect(with: maxSize, options: options, context: nil).size
+            size = newAttributedString.boundingRect(with: maxSize, options: options, context: nil).size
         case .unattributed(let text):
             if text.isEmpty {
                 return .zero
             }
-            size = text.boundingRect(with: maxSize, options: options, attributes: [NSAttributedString.Key.font: font], context: nil).size
+            size = text.boundingRect(with: maxSize, options: options, attributes: attributes, context: nil).size
         }
         // boundingRect(with:options:attributes:) returns size to a precision of hundredths of a point,
         // but UILabel only returns sizes with a point precision of 1/screenDensity.


### PR DESCRIPTION
- Added line break mode support in LabelLayout to calculate correct size based on line break mode.
- Added LabelLayout unit test to verify that size calculation logic considers line break mode while calculating LabelLayout size.
- These changes are duplicate of pull request https://github.com/linkedin/LayoutKit/pull/229